### PR TITLE
feat: networks lifecycle (#4)

### DIFF
--- a/app/src/app/actions/networks.ts
+++ b/app/src/app/actions/networks.ts
@@ -1,0 +1,90 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+import { revalidatePath } from 'next/cache'
+import { createSupabaseServerClient } from '@/lib/supabase/server'
+
+export type NetworkActionState = { error?: string } | undefined
+
+// ---------------------------------------------------------------------------
+// createNetworkAction — uses RPC so network + owner membership are atomic.
+// Used with useActionState (prevState, formData).
+// ---------------------------------------------------------------------------
+export async function createNetworkAction(
+  _state: NetworkActionState,
+  formData: FormData
+): Promise<NetworkActionState> {
+  const name = (formData.get('name') as string)?.trim()
+  if (!name) return { error: 'Name is required.' }
+
+  const supabase = await createSupabaseServerClient()
+  const { data: networkId, error } = await supabase.rpc('create_network', { p_name: name })
+  if (error) return { error: error.message }
+
+  redirect(`/networks/${networkId}`)
+}
+
+// ---------------------------------------------------------------------------
+// renameNetworkAction — plain form action (no state needed; page reloads).
+// ---------------------------------------------------------------------------
+export async function renameNetworkAction(formData: FormData): Promise<void> {
+  const networkId = formData.get('network_id') as string
+  const name = (formData.get('name') as string)?.trim()
+  if (!networkId || !name) return
+
+  const supabase = await createSupabaseServerClient()
+  await supabase.from('networks').update({ name }).eq('id', networkId)
+  revalidatePath(`/networks/${networkId}`)
+}
+
+// ---------------------------------------------------------------------------
+// deleteNetworkAction — owner only (RLS enforces). Redirects to list.
+// ---------------------------------------------------------------------------
+export async function deleteNetworkAction(formData: FormData): Promise<void> {
+  const networkId = formData.get('network_id') as string
+  if (!networkId) return
+
+  const supabase = await createSupabaseServerClient()
+  await supabase.from('networks').delete().eq('id', networkId)
+  redirect('/networks')
+}
+
+// ---------------------------------------------------------------------------
+// leaveNetworkAction — member deletes own membership. Redirects to list.
+// ---------------------------------------------------------------------------
+export async function leaveNetworkAction(formData: FormData): Promise<void> {
+  const networkId = formData.get('network_id') as string
+  if (!networkId) return
+
+  const supabase = await createSupabaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return
+
+  await supabase
+    .from('memberships')
+    .delete()
+    .eq('network_id', networkId)
+    .eq('user_id', user.id)
+
+  redirect('/networks')
+}
+
+// ---------------------------------------------------------------------------
+// removeMemberAction — owner removes another member (RLS enforces).
+// ---------------------------------------------------------------------------
+export async function removeMemberAction(formData: FormData): Promise<void> {
+  const networkId = formData.get('network_id') as string
+  const targetUserId = formData.get('user_id') as string
+  if (!networkId || !targetUserId) return
+
+  const supabase = await createSupabaseServerClient()
+  await supabase
+    .from('memberships')
+    .delete()
+    .eq('network_id', networkId)
+    .eq('user_id', targetUserId)
+
+  revalidatePath(`/networks/${networkId}`)
+}

--- a/app/src/app/networks/[id]/page.tsx
+++ b/app/src/app/networks/[id]/page.tsx
@@ -64,6 +64,7 @@ export default async function NetworkDetailPage({ params }: Props) {
               type="text"
               defaultValue={network.name}
               required
+              suppressHydrationWarning
             />
             <button type="submit">Save</button>
           </form>

--- a/app/src/app/networks/[id]/page.tsx
+++ b/app/src/app/networks/[id]/page.tsx
@@ -1,0 +1,107 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server'
+import { notFound } from 'next/navigation'
+import {
+  renameNetworkAction,
+  deleteNetworkAction,
+  leaveNetworkAction,
+  removeMemberAction,
+} from '@/app/actions/networks'
+
+interface Props {
+  params: Promise<{ id: string }>
+}
+
+// PostgREST returns a single object for many-to-one FK joins at runtime.
+// TypeScript infers array without generated types — cast via unknown below.
+type MemberRow = {
+  role: string
+  user_id: string
+  profiles: { username: string } | null
+}
+
+export default async function NetworkDetailPage({ params }: Props) {
+  const { id } = await params
+  const supabase = await createSupabaseServerClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  const { data: network } = await supabase
+    .from('networks')
+    .select('id, name, owner_id')
+    .eq('id', id)
+    .single()
+
+  if (!network) notFound()
+
+  const { data: membersRaw } = await supabase
+    .from('memberships')
+    .select('role, user_id, profiles(username)')
+    .eq('network_id', id)
+    .order('role', { ascending: false }) // 'owner' before 'member'
+
+  const members = (membersRaw ?? []) as unknown as MemberRow[]
+  const isOwner = network.owner_id === user!.id
+
+  return (
+    <main>
+      <nav>
+        <a href="/networks">← Networks</a>
+      </nav>
+
+      <h1>{network.name}</h1>
+
+      {isOwner && (
+        <section>
+          <h2>Rename</h2>
+          <form action={renameNetworkAction}>
+            <input type="hidden" name="network_id" value={id} />
+            <label htmlFor="rename-input">New name</label>
+            <input
+              id="rename-input"
+              name="name"
+              type="text"
+              defaultValue={network.name}
+              required
+            />
+            <button type="submit">Save</button>
+          </form>
+        </section>
+      )}
+
+      <section>
+        <h2>Members</h2>
+        <ul>
+          {members.map((m) => (
+            <li key={m.user_id}>
+              <span>{m.profiles?.username ?? m.user_id}</span>
+              <span> — {m.role}</span>
+              {isOwner && m.user_id !== user!.id && (
+                <form action={removeMemberAction} style={{ display: 'inline', marginLeft: '0.5rem' }}>
+                  <input type="hidden" name="network_id" value={id} />
+                  <input type="hidden" name="user_id" value={m.user_id} />
+                  <button type="submit">Remove</button>
+                </form>
+              )}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        {isOwner ? (
+          <form action={deleteNetworkAction}>
+            <input type="hidden" name="network_id" value={id} />
+            <button type="submit">Delete Network</button>
+          </form>
+        ) : (
+          <form action={leaveNetworkAction}>
+            <input type="hidden" name="network_id" value={id} />
+            <button type="submit">Leave Network</button>
+          </form>
+        )}
+      </section>
+    </main>
+  )
+}

--- a/app/src/app/networks/create-network-form.tsx
+++ b/app/src/app/networks/create-network-form.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { useActionState } from 'react'
+import { createNetworkAction } from '@/app/actions/networks'
+
+export default function CreateNetworkForm() {
+  const [state, action, pending] = useActionState(createNetworkAction, undefined)
+
+  return (
+    <form action={action}>
+      <label htmlFor="network-name">Network name</label>
+      <input id="network-name" name="name" type="text" required placeholder="e.g. Trail Crew" />
+      {state?.error && <p role="alert">{state.error}</p>}
+      <button type="submit" disabled={pending} suppressHydrationWarning>
+        {pending ? 'Creating…' : 'Create Network'}
+      </button>
+    </form>
+  )
+}

--- a/app/src/app/networks/create-network-form.tsx
+++ b/app/src/app/networks/create-network-form.tsx
@@ -9,7 +9,7 @@ export default function CreateNetworkForm() {
   return (
     <form action={action}>
       <label htmlFor="network-name">Network name</label>
-      <input id="network-name" name="name" type="text" required placeholder="e.g. Trail Crew" />
+      <input id="network-name" name="name" type="text" required placeholder="e.g. Trail Crew" suppressHydrationWarning />
       {state?.error && <p role="alert">{state.error}</p>}
       <button type="submit" disabled={pending} suppressHydrationWarning>
         {pending ? 'Creating…' : 'Create Network'}

--- a/app/src/app/networks/page.tsx
+++ b/app/src/app/networks/page.tsx
@@ -1,0 +1,45 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server'
+import CreateNetworkForm from './create-network-form'
+
+export default async function NetworksPage() {
+  const supabase = await createSupabaseServerClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  const { data: networks } = await supabase
+    .from('networks')
+    .select('id, name, owner_id')
+    .order('created_at', { ascending: false })
+
+  return (
+    <main>
+      <header>
+        <a href="/">← Home</a>
+        <h1>Networks</h1>
+      </header>
+
+      <section>
+        <h2>Create a Network</h2>
+        <CreateNetworkForm />
+      </section>
+
+      <section>
+        <h2>Your Networks</h2>
+        {networks && networks.length > 0 ? (
+          <ul>
+            {networks.map((n) => (
+              <li key={n.id}>
+                <a href={`/networks/${n.id}`}>{n.name}</a>
+                {n.owner_id === user!.id && <span> (owner)</span>}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p>No networks yet. Create one above.</p>
+        )}
+      </section>
+    </main>
+  )
+}

--- a/app/supabase/migrations/0005_create_network_fn.sql
+++ b/app/supabase/migrations/0005_create_network_fn.sql
@@ -1,0 +1,26 @@
+-- Atomic network creation: inserts network + owner membership in one call.
+-- Needed because networks_select RLS uses is_network_member(id), so the
+-- creator cannot SELECT the row they just inserted until membership exists.
+create or replace function public.create_network(p_name text)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_network_id uuid;
+begin
+  insert into public.networks (name, owner_id)
+  values (p_name, auth.uid())
+  returning id into v_network_id;
+
+  insert into public.memberships (user_id, network_id, role)
+  values (auth.uid(), v_network_id, 'owner');
+
+  return v_network_id;
+end;
+$$;
+
+-- Revoke public execute, grant to authenticated only
+revoke execute on function public.create_network(text) from public;
+grant execute on function public.create_network(text) to authenticated;

--- a/app/tests/integration/networks/lifecycle.test.ts
+++ b/app/tests/integration/networks/lifecycle.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Networks lifecycle — Cycles N1–N8
+ *
+ * Verifies RLS + schema support the full Network lifecycle:
+ * create, rename, delete, member management, multi-network membership,
+ * and spot survival across network deletes.
+ *
+ * Design: one module-level beforeAll creates 3 shared clients (owner,
+ * member, outsider) to minimise signInWithPassword calls and avoid rate limits.
+ * Each describe creates its own network via admin (bypasses RLS) so cycles
+ * stay independent.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import {
+  createUser,
+  signIn,
+  cleanupUsers,
+  seedNetwork,
+  seedMembership,
+  seedSpot,
+  admin,
+} from '../helpers/seed'
+
+// ---------------------------------------------------------------------------
+// Shared test principals — created once for all cycles
+// ---------------------------------------------------------------------------
+let ownerId: string
+let memberId: string
+let outsiderId: string
+let ownerClient: SupabaseClient
+let memberClient: SupabaseClient
+let outsiderClient: SupabaseClient
+
+beforeAll(async () => {
+  const owner = await createUser('nlc-owner')
+  const member = await createUser('nlc-member')
+  const outsider = await createUser('nlc-outsider')
+
+  ownerId = owner.id
+  memberId = member.id
+  outsiderId = outsider.id
+
+  // 3 signIn calls total for the entire suite
+  ownerClient = await signIn(owner.email, owner.password)
+  memberClient = await signIn(member.email, member.password)
+  outsiderClient = await signIn(outsider.email, outsider.password)
+})
+
+afterAll(async () => {
+  await cleanupUsers([ownerId, memberId, outsiderId])
+})
+
+// ---------------------------------------------------------------------------
+// Cycle N1: Owner creates a Network
+//
+// RLS note: networks_select uses is_network_member(id), so after INSERT the
+// owner cannot SELECT the row yet (no membership). Do NOT chain .select() —
+// get the ID via admin, insert membership, then verify SELECT works.
+// ---------------------------------------------------------------------------
+describe('N1: Owner creates a Network', () => {
+  it('RLS allows INSERT with owner_id = auth.uid(); SELECT works after membership added', async () => {
+    // INSERT without .select() — user can't see their own network yet (no membership)
+    const { error: netErr } = await ownerClient
+      .from('networks')
+      .insert({ name: 'N1 Network', owner_id: ownerId })
+
+    expect(netErr).toBeNull()
+
+    // Retrieve ID via admin
+    const { data: net } = await admin
+      .from('networks')
+      .select('id, name, owner_id')
+      .eq('owner_id', ownerId)
+      .eq('name', 'N1 Network')
+      .single()
+
+    expect(net).not.toBeNull()
+    expect(net!.owner_id).toBe(ownerId)
+
+    // Insert owner membership
+    const { error: memErr } = await ownerClient
+      .from('memberships')
+      .insert({ user_id: ownerId, network_id: net!.id, role: 'owner' })
+
+    expect(memErr).toBeNull()
+
+    // Owner can now SELECT own network (has membership)
+    const { data: visible } = await ownerClient
+      .from('networks')
+      .select('id, name')
+      .eq('id', net!.id)
+      .single()
+
+    expect(visible!.name).toBe('N1 Network')
+
+    // Cleanup
+    await admin.from('networks').delete().eq('id', net!.id)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cycle N2: Owner renames; non-owner is blocked
+// ---------------------------------------------------------------------------
+describe('N2: Owner renames a Network', () => {
+  let networkId: string
+
+  beforeAll(async () => {
+    networkId = await seedNetwork(ownerId, 'N2 Original')
+    await seedMembership(memberId, networkId, 'member')
+  })
+
+  afterAll(async () => {
+    await admin.from('networks').delete().eq('id', networkId)
+  })
+
+  it('owner can rename the network', async () => {
+    const { data, error } = await ownerClient
+      .from('networks')
+      .update({ name: 'N2 Renamed' })
+      .eq('id', networkId)
+      .select('name')
+      .single()
+
+    expect(error).toBeNull()
+    expect(data!.name).toBe('N2 Renamed')
+  })
+
+  it('non-owner cannot rename (RLS blocks update)', async () => {
+    const { data, error } = await memberClient
+      .from('networks')
+      .update({ name: 'N2 Hacked' })
+      .eq('id', networkId)
+      .select('name')
+
+    expect(error).toBeNull()
+    expect(data).toHaveLength(0)
+
+    const { data: net } = await admin
+      .from('networks')
+      .select('name')
+      .eq('id', networkId)
+      .single()
+    expect(net!.name).toBe('N2 Renamed')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cycle N3: Owner deletes; memberships cascade
+// ---------------------------------------------------------------------------
+describe('N3: Owner deletes a Network', () => {
+  let networkId: string
+
+  beforeAll(async () => {
+    networkId = await seedNetwork(ownerId, 'N3 Delete Me')
+    await seedMembership(memberId, networkId, 'member')
+  })
+
+  // No afterAll — network is deleted in the test
+
+  it('owner can delete; memberships cascade', async () => {
+    const { error } = await ownerClient.from('networks').delete().eq('id', networkId)
+    expect(error).toBeNull()
+
+    const { data: nets } = await admin.from('networks').select('id').eq('id', networkId)
+    expect(nets).toHaveLength(0)
+
+    const { data: mems } = await admin
+      .from('memberships')
+      .select('user_id')
+      .eq('network_id', networkId)
+    expect(mems).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cycle N4: Owner removes a member; non-owner cannot remove others
+// ---------------------------------------------------------------------------
+describe('N4: Owner removes a member', () => {
+  let networkId: string
+
+  beforeAll(async () => {
+    networkId = await seedNetwork(ownerId, 'N4 Manage')
+    await seedMembership(memberId, networkId, 'member')
+    await seedMembership(outsiderId, networkId, 'member') // outsider plays memberB role here
+  })
+
+  afterAll(async () => {
+    await admin.from('networks').delete().eq('id', networkId)
+  })
+
+  it('non-owner cannot remove another member (RLS blocks)', async () => {
+    const { error } = await memberClient
+      .from('memberships')
+      .delete()
+      .eq('user_id', outsiderId)
+      .eq('network_id', networkId)
+
+    expect(error).toBeNull()
+
+    // outsider still in network
+    const { data: mems } = await admin
+      .from('memberships')
+      .select('user_id')
+      .eq('user_id', outsiderId)
+      .eq('network_id', networkId)
+    expect(mems).toHaveLength(1)
+  })
+
+  it('owner can remove a member', async () => {
+    const { error } = await ownerClient
+      .from('memberships')
+      .delete()
+      .eq('user_id', outsiderId)
+      .eq('network_id', networkId)
+
+    expect(error).toBeNull()
+
+    const { data: mems } = await admin
+      .from('memberships')
+      .select('user_id')
+      .eq('user_id', outsiderId)
+      .eq('network_id', networkId)
+    expect(mems).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cycle N5: Member leaves a Network
+// ---------------------------------------------------------------------------
+describe('N5: Member leaves a Network', () => {
+  let networkId: string
+
+  beforeAll(async () => {
+    networkId = await seedNetwork(ownerId, 'N5 Leave')
+    await seedMembership(memberId, networkId, 'member')
+  })
+
+  afterAll(async () => {
+    await admin.from('networks').delete().eq('id', networkId)
+  })
+
+  it('member can delete own membership (leave)', async () => {
+    const { error } = await memberClient
+      .from('memberships')
+      .delete()
+      .eq('user_id', memberId)
+      .eq('network_id', networkId)
+
+    expect(error).toBeNull()
+
+    const { data: mems } = await admin
+      .from('memberships')
+      .select('user_id')
+      .eq('user_id', memberId)
+      .eq('network_id', networkId)
+    expect(mems).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cycle N6: Member list shows usernames and roles
+// ---------------------------------------------------------------------------
+describe('N6: Member list shows usernames and roles', () => {
+  let networkId: string
+
+  beforeAll(async () => {
+    networkId = await seedNetwork(ownerId, 'N6 Members')
+    await seedMembership(memberId, networkId, 'member')
+    // outsider NOT added — used to test visibility block
+  })
+
+  afterAll(async () => {
+    await admin.from('networks').delete().eq('id', networkId)
+  })
+
+  it('member sees all members with usernames and roles', async () => {
+    const { data, error } = await memberClient
+      .from('memberships')
+      .select('role, user_id, profiles(username)')
+      .eq('network_id', networkId)
+      .order('role')
+
+    expect(error).toBeNull()
+    expect(data).not.toBeNull()
+    expect(data!.length).toBe(2)
+
+    const roles = data!.map((m) => m.role).sort()
+    expect(roles).toContain('owner')
+    expect(roles).toContain('member')
+
+    for (const row of data!) {
+      // PostgREST returns a single object for many-to-one FK joins at runtime.
+      // TypeScript infers array without generated types — cast via unknown.
+      const profile = row.profiles as unknown as { username: string } | null
+      expect(profile?.username).toBeTruthy()
+    }
+  })
+
+  it('outsider cannot see the member list (RLS blocks)', async () => {
+    const { data, error } = await outsiderClient
+      .from('memberships')
+      .select('role, profiles(username)')
+      .eq('network_id', networkId)
+
+    expect(error).toBeNull()
+    expect(data).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cycle N7: User belongs to multiple Networks simultaneously
+// ---------------------------------------------------------------------------
+describe('N7: User belongs to multiple Networks simultaneously', () => {
+  let networkAId: string
+  let networkBId: string
+
+  beforeAll(async () => {
+    networkAId = await seedNetwork(ownerId, 'N7 Alpha')
+    networkBId = await seedNetwork(ownerId, 'N7 Beta')
+    await seedMembership(memberId, networkAId, 'member')
+    await seedMembership(memberId, networkBId, 'member')
+  })
+
+  afterAll(async () => {
+    await admin.from('networks').delete().eq('id', networkAId)
+    await admin.from('networks').delete().eq('id', networkBId)
+  })
+
+  it('user sees both networks in membership list', async () => {
+    const { data, error } = await memberClient
+      .from('memberships')
+      .select('network_id')
+      .eq('user_id', memberId)
+      .in('network_id', [networkAId, networkBId])
+
+    expect(error).toBeNull()
+    const ids = data!.map((m) => m.network_id)
+    expect(ids).toContain(networkAId)
+    expect(ids).toContain(networkBId)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cycle N8: Delete Network removes memberships; shared Spot survives
+// ---------------------------------------------------------------------------
+describe('N8: Delete Network cleans up memberships; shared Spots survive', () => {
+  let networkToDeleteId: string
+  let networkKeepId: string
+  let spotId: string
+
+  beforeAll(async () => {
+    networkToDeleteId = await seedNetwork(ownerId, 'N8 Delete Me')
+    networkKeepId = await seedNetwork(ownerId, 'N8 Keep Me')
+
+    await seedMembership(memberId, networkToDeleteId, 'member')
+    await seedMembership(memberId, networkKeepId, 'member')
+
+    spotId = await seedSpot(ownerId, [networkToDeleteId, networkKeepId], { title: 'N8 Survivor' })
+  })
+
+  afterAll(async () => {
+    await admin.from('networks').delete().eq('id', networkKeepId)
+  })
+
+  it('deleting a Network removes its memberships', async () => {
+    await admin.from('networks').delete().eq('id', networkToDeleteId)
+
+    const { data: mems } = await admin
+      .from('memberships')
+      .select('user_id')
+      .eq('network_id', networkToDeleteId)
+    expect(mems).toHaveLength(0)
+  })
+
+  it('Spot shared with remaining Network still visible to its member', async () => {
+    const { data } = await memberClient.from('spots').select('id').eq('id', spotId)
+    expect(data).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary

- **`/networks`** — lists user's networks (RLS-filtered); create form via `create_network()` RPC
- **`/networks/[id]`** — detail page: member list with usernames+roles, rename/delete (owner), leave (member), remove member (owner)
- **Migration `0005`** — `create_network(name)` security-definer function inserts network + owner membership atomically (needed because `networks_select` RLS uses `is_network_member`, so user can't see their own network until membership exists)
- **Integration tests N1–N8** — cover all acceptance criteria via real Supabase RLS

Closes #4. Requires #3 (auth) to already be deployed — middleware in `proxy.ts` redirects unauthenticated users to `/login`.

## Acceptance criteria status

| Criterion | Verified by |
|-----------|------------|
| Owner can create Network | N1 test + UI |
| Owner can rename Network | N2 test + UI |
| Owner can delete Network | N3 test + UI |
| Owner can remove a Member | N4 test + UI |
| Any Member can leave | N5 test + UI |
| Member list shows usernames + roles | N6 test + UI |
| User belongs to multiple Networks | N7 test |
| Delete removes memberships; shared Spots survive | N8 test |

## Human QA steps

**Prerequisites:** app running (`npm run dev` on port 3001), two registered accounts (User A = owner, User B = member).

1. **Create Network**
   - Log in as User A → navigate to `/networks`
   - Enter a name → click **Create Network**
   - Expected: redirected to `/networks/<id>`, network name shown, User A listed as `owner`

2. **Rename Network**
   - On the detail page (as owner), edit the name field → click **Save**
   - Expected: page reloads, new name shown in `<h1>`

3. **Member joins (seed via DB or invite)**
   - Add User B as member via Supabase dashboard or admin client
   - Log in as User B → `/networks` → confirm network appears

4. **Member list**
   - As either user, visit `/networks/<id>`
   - Expected: both users listed with correct roles (`owner` / `member`)

5. **Owner removes member**
   - As User A, click **Remove** next to User B
   - Expected: User B disappears from member list; User B's `/networks` no longer shows network

6. **Member leaves**
   - Add User B back → log in as User B → `/networks/<id>` → click **Leave Network**
   - Expected: redirected to `/networks`, network no longer listed

7. **Delete Network**
   - Log in as User A → `/networks/<id>` → click **Delete Network**
   - Expected: redirected to `/networks`, network gone; User B (if re-added) also lost access

8. **Multiple Networks**
   - Create two networks as User A, add User B to both
   - Log in as User B → `/networks` → confirm both networks listed

9. **Auth protection**
   - Log out, visit `/networks` directly
   - Expected: redirected to `/login?next=/networks`

🤖 Generated with [Claude Code](https://claude.com/claude-code)