### PR TITLE
feat: invitation flow — generate, join, expire, revoke

### DIFF
--- a/app/src/app/actions/auth.ts
+++ b/app/src/app/actions/auth.ts
@@ -22,6 +22,8 @@ export async function registerAction(
     return { error: 'All fields are required.' }
   }
 
+  const inviteToken = formData.get('invite_token') as string | null
+
   const supabase = await createSupabaseServerClient()
   const { error } = await supabase.auth.signUp({
     email,
@@ -30,6 +32,12 @@ export async function registerAction(
   })
 
   if (error) return { error: error.message }
+
+  if (inviteToken) {
+    const { data: networkId } = await supabase.rpc('join_by_token', { p_token: inviteToken })
+    if (networkId) redirect(`/networks/${networkId}`)
+  }
+
   redirect('/')
 }
 

--- a/app/src/app/actions/auth.ts
+++ b/app/src/app/actions/auth.ts
@@ -48,6 +48,14 @@ export async function registerAction(
     if (networkId) redirect(`/networks/${networkId}`)
   }
 
+  // No session yet (email confirmation required). If there's an invite token,
+  // tell the user to confirm their email and return to the invite link after.
+  if (inviteToken && !data.session) {
+    return {
+      message: `Check your email for a confirmation link. After confirming, return to ${siteUrl}/invite/${inviteToken} to join the network.`,
+    }
+  }
+
   redirect('/')
 }
 

--- a/app/src/app/actions/auth.ts
+++ b/app/src/app/actions/auth.ts
@@ -25,15 +25,25 @@ export async function registerAction(
   const inviteToken = formData.get('invite_token') as string | null
 
   const supabase = await createSupabaseServerClient()
-  const { error } = await supabase.auth.signUp({
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'
+
+  const { data, error } = await supabase.auth.signUp({
     email,
     password,
-    options: { data: { username } },
+    options: {
+      data: { username },
+      // If an invite token is present, route the confirmation email back through
+      // the invite page so the user lands there already authenticated.
+      ...(inviteToken && {
+        emailRedirectTo: `${siteUrl}/auth/confirm?next=/invite/${inviteToken}`,
+      }),
+    },
   })
 
   if (error) return { error: error.message }
 
-  if (inviteToken) {
+  // Email confirmation disabled — session is available immediately. Join now.
+  if (inviteToken && data.session) {
     const { data: networkId } = await supabase.rpc('join_by_token', { p_token: inviteToken })
     if (networkId) redirect(`/networks/${networkId}`)
   }

--- a/app/src/app/actions/invitations.ts
+++ b/app/src/app/actions/invitations.ts
@@ -1,0 +1,68 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+import { revalidatePath } from 'next/cache'
+import { createSupabaseServerClient } from '@/lib/supabase/server'
+
+export type InvitationActionState = { error?: string; token?: string } | undefined
+
+// ---------------------------------------------------------------------------
+// createInvitationAction — member generates a new invite link for their network.
+// Returns the token in state so the UI can display the full URL.
+// ---------------------------------------------------------------------------
+export async function createInvitationAction(
+  _state: InvitationActionState,
+  formData: FormData
+): Promise<InvitationActionState> {
+  const networkId = formData.get('network_id') as string
+  if (!networkId) return { error: 'Network ID is required.' }
+
+  const supabase = await createSupabaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return { error: 'Not authenticated.' }
+
+  const { data, error } = await supabase
+    .from('invitations')
+    .insert({ network_id: networkId, created_by: user.id })
+    .select('token')
+    .single()
+
+  if (error) return { error: error.message }
+  return { token: data.token }
+}
+
+// ---------------------------------------------------------------------------
+// revokeInvitationAction — owner revokes an active invitation (RLS enforces).
+// ---------------------------------------------------------------------------
+export async function revokeInvitationAction(formData: FormData): Promise<void> {
+  const invitationId = formData.get('invitation_id') as string
+  const networkId = formData.get('network_id') as string
+  if (!invitationId || !networkId) return
+
+  const supabase = await createSupabaseServerClient()
+  await supabase
+    .from('invitations')
+    .update({ revoked_at: new Date().toISOString() })
+    .eq('id', invitationId)
+
+  revalidatePath(`/networks/${networkId}`)
+}
+
+// ---------------------------------------------------------------------------
+// joinByTokenAction — authenticated user joins a network via invite token.
+// ---------------------------------------------------------------------------
+export async function joinByTokenAction(
+  _state: InvitationActionState,
+  formData: FormData
+): Promise<InvitationActionState> {
+  const token = formData.get('token') as string
+  if (!token) return { error: 'Token is required.' }
+
+  const supabase = await createSupabaseServerClient()
+  const { data: networkId, error } = await supabase.rpc('join_by_token', { p_token: token })
+
+  if (error) return { error: error.message }
+  redirect(`/networks/${networkId}`)
+}

--- a/app/src/app/invite/[token]/join-network-form.tsx
+++ b/app/src/app/invite/[token]/join-network-form.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { useActionState } from 'react'
+import { joinByTokenAction } from '@/app/actions/invitations'
+
+interface Props {
+  token: string
+}
+
+export default function JoinNetworkForm({ token }: Props) {
+  const [state, action, pending] = useActionState(joinByTokenAction, undefined)
+
+  return (
+    <form action={action}>
+      <input type="hidden" name="token" value={token} />
+      {state?.error && <p role="alert">{state.error}</p>}
+      <button type="submit" disabled={pending}>
+        {pending ? 'Joining…' : 'Join Network'}
+      </button>
+    </form>
+  )
+}

--- a/app/src/app/invite/[token]/page.tsx
+++ b/app/src/app/invite/[token]/page.tsx
@@ -1,0 +1,61 @@
+import { redirect } from 'next/navigation'
+import { createSupabaseServerClient } from '@/lib/supabase/server'
+import JoinNetworkForm from './join-network-form'
+
+interface Props {
+  params: Promise<{ token: string }>
+}
+
+export default async function InvitePage({ params }: Props) {
+  const { token } = await params
+  const supabase = await createSupabaseServerClient()
+
+  const { data: rows } = await supabase.rpc('lookup_invitation', { p_token: token })
+  const result = rows?.[0]
+
+  if (!result || result.status === 'not_found') {
+    return (
+      <main>
+        <h1>Invalid invitation link.</h1>
+        <p>This invitation link is not valid.</p>
+      </main>
+    )
+  }
+
+  if (result.status === 'expired') {
+    return (
+      <main>
+        <h1>Invitation expired</h1>
+        <p>This invitation has expired.</p>
+      </main>
+    )
+  }
+
+  if (result.status === 'revoked') {
+    return (
+      <main>
+        <h1>Invitation revoked</h1>
+        <p>This invitation has been revoked.</p>
+      </main>
+    )
+  }
+
+  // Valid token — check auth
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect(`/register?token=${token}`)
+  }
+
+  return (
+    <main>
+      <h1>You&apos;re invited!</h1>
+      <p>
+        Join <strong>{result.network_name}</strong>
+      </p>
+      <JoinNetworkForm token={token} />
+    </main>
+  )
+}

--- a/app/src/app/networks/[id]/generate-invite-form.tsx
+++ b/app/src/app/networks/[id]/generate-invite-form.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useActionState } from 'react'
+import { createInvitationAction } from '@/app/actions/invitations'
+
+interface Props {
+  networkId: string
+}
+
+const siteUrl =
+  typeof process !== 'undefined' && process.env.NEXT_PUBLIC_SITE_URL
+    ? process.env.NEXT_PUBLIC_SITE_URL
+    : ''
+
+export default function GenerateInviteForm({ networkId }: Props) {
+  const [state, action, pending] = useActionState(createInvitationAction, undefined)
+
+  const inviteUrl = state?.token ? `${siteUrl}/invite/${state.token}` : null
+
+  return (
+    <div>
+      <form action={action}>
+        <input type="hidden" name="network_id" value={networkId} />
+        <button type="submit" disabled={pending}>
+          {pending ? 'Generating…' : 'Generate invite link'}
+        </button>
+      </form>
+      {state?.error && <p role="alert">{state.error}</p>}
+      {inviteUrl && (
+        <p>
+          <span>Invite link: </span>
+          <code>{inviteUrl}</code>
+        </p>
+      )}
+    </div>
+  )
+}

--- a/app/src/app/networks/[id]/page.tsx
+++ b/app/src/app/networks/[id]/page.tsx
@@ -6,6 +6,8 @@ import {
   leaveNetworkAction,
   removeMemberAction,
 } from '@/app/actions/networks'
+import { revokeInvitationAction } from '@/app/actions/invitations'
+import GenerateInviteForm from './generate-invite-form'
 
 interface Props {
   params: Promise<{ id: string }>
@@ -41,6 +43,14 @@ export default async function NetworkDetailPage({ params }: Props) {
     .eq('network_id', id)
     .order('role', { ascending: false }) // 'owner' before 'member'
 
+  const { data: activeInvitations } = await supabase
+    .from('invitations')
+    .select('id, token, expires_at, created_at')
+    .eq('network_id', id)
+    .gt('expires_at', new Date().toISOString())
+    .is('revoked_at', null)
+    .order('created_at', { ascending: false })
+
   const members = (membersRaw ?? []) as unknown as MemberRow[]
   const isOwner = network.owner_id === user!.id
 
@@ -70,6 +80,28 @@ export default async function NetworkDetailPage({ params }: Props) {
           </form>
         </section>
       )}
+
+      <section>
+        <h2>Invite Members</h2>
+        <GenerateInviteForm networkId={id} />
+        {isOwner && activeInvitations && activeInvitations.length > 0 && (
+          <div>
+            <h3>Active invite links</h3>
+            <ul>
+              {activeInvitations.map((inv) => (
+                <li key={inv.id}>
+                  <span>Expires: {new Date(inv.expires_at).toLocaleDateString()}</span>
+                  <form action={revokeInvitationAction} style={{ display: 'inline', marginLeft: '0.5rem' }}>
+                    <input type="hidden" name="invitation_id" value={inv.id} />
+                    <input type="hidden" name="network_id" value={id} />
+                    <button type="submit">Revoke</button>
+                  </form>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </section>
 
       <section>
         <h2>Members</h2>

--- a/app/src/app/register/page.tsx
+++ b/app/src/app/register/page.tsx
@@ -1,10 +1,15 @@
 import RegisterForm from './register-form'
 
-export default function RegisterPage() {
+interface Props {
+  searchParams: Promise<{ token?: string }>
+}
+
+export default async function RegisterPage({ searchParams }: Props) {
+  const { token } = await searchParams
   return (
     <main>
       <h1>Create account</h1>
-      <RegisterForm />
+      <RegisterForm inviteToken={token} />
       <p>
         Already have an account? <a href="/login">Log in</a>
       </p>

--- a/app/src/app/register/register-form.tsx
+++ b/app/src/app/register/register-form.tsx
@@ -3,11 +3,16 @@
 import { useActionState } from 'react'
 import { registerAction } from '@/app/actions/auth'
 
-export default function RegisterForm() {
+interface Props {
+  inviteToken?: string
+}
+
+export default function RegisterForm({ inviteToken }: Props) {
   const [state, action, pending] = useActionState(registerAction, undefined)
 
   return (
     <form action={action}>
+      {inviteToken && <input type="hidden" name="invite_token" value={inviteToken} />}
       <div>
         <label htmlFor="username">Username</label>
         <input id="username" name="username" type="text" required autoComplete="username" suppressHydrationWarning />

--- a/app/src/app/register/register-form.tsx
+++ b/app/src/app/register/register-form.tsx
@@ -36,6 +36,7 @@ export default function RegisterForm({ inviteToken }: Props) {
       </div>
 
       {state?.error && <p role="alert">{state.error}</p>}
+      {state?.message && <p>{state.message}</p>}
 
       <button type="submit" disabled={pending} suppressHydrationWarning>
         {pending ? 'Creating account…' : 'Create account'}

--- a/app/src/proxy.ts
+++ b/app/src/proxy.ts
@@ -45,7 +45,7 @@ export async function proxy(request: NextRequest) {
 
   const { pathname } = request.nextUrl
 
-  if (!PUBLIC_PATHS.has(pathname) && !user) {
+  if (!PUBLIC_PATHS.has(pathname) && !pathname.startsWith('/invite/') && !user) {
     const loginUrl = new URL('/login', request.url)
     loginUrl.searchParams.set('next', pathname)
     return NextResponse.redirect(loginUrl)

--- a/app/supabase/migrations/0006_invitation_rpcs.sql
+++ b/app/supabase/migrations/0006_invitation_rpcs.sql
@@ -1,0 +1,72 @@
+-- lookup_invitation: publicly callable (anon) security-definer function.
+-- Returns the network name and validity status for a given invite token.
+-- No auth required — used by the /invite/[token] page before sign-in.
+create or replace function public.lookup_invitation(p_token text)
+returns table(network_id uuid, network_name text, status text)
+language plpgsql security definer stable set search_path = public as $$
+declare
+  v_network_id uuid;
+  v_network_name text;
+  v_expires_at timestamptz;
+  v_revoked_at timestamptz;
+begin
+  select i.network_id, n.name, i.expires_at, i.revoked_at
+  into v_network_id, v_network_name, v_expires_at, v_revoked_at
+  from invitations i
+  join networks n on n.id = i.network_id
+  where i.token = p_token;
+
+  if not found then
+    return query select null::uuid, null::text, 'not_found'::text;
+    return;
+  end if;
+
+  if v_revoked_at is not null then
+    return query select v_network_id, v_network_name, 'revoked'::text;
+    return;
+  end if;
+
+  if v_expires_at < now() then
+    return query select v_network_id, v_network_name, 'expired'::text;
+    return;
+  end if;
+
+  return query select v_network_id, v_network_name, 'valid'::text;
+end;
+$$;
+
+-- join_by_token: requires auth. Validates token and inserts membership.
+-- Idempotent: ON CONFLICT DO NOTHING if already a member.
+-- Returns the network_id on success; raises an exception on failure.
+create or replace function public.join_by_token(p_token text)
+returns uuid
+language plpgsql security definer set search_path = public as $$
+declare
+  v_network_id uuid;
+  v_expires_at timestamptz;
+  v_revoked_at timestamptz;
+begin
+  select network_id, expires_at, revoked_at
+  into v_network_id, v_expires_at, v_revoked_at
+  from invitations
+  where token = p_token;
+
+  if not found then
+    raise exception 'Invitation not found.';
+  end if;
+
+  if v_revoked_at is not null then
+    raise exception 'Invitation has been revoked.';
+  end if;
+
+  if v_expires_at < now() then
+    raise exception 'Invitation has expired.';
+  end if;
+
+  insert into memberships (user_id, network_id, role)
+  values (auth.uid(), v_network_id, 'member')
+  on conflict (user_id, network_id) do nothing;
+
+  return v_network_id;
+end;
+$$;

--- a/app/tests/integration/helpers/seed.ts
+++ b/app/tests/integration/helpers/seed.ts
@@ -74,6 +74,21 @@ export async function seedMembership(userId: string, networkId: string, role = '
   if (error) throw new Error(`seedMembership failed: ${error.message}`)
 }
 
+/** Seed an invitation for a network via admin; returns { id, token } */
+export async function seedInvitation(
+  networkId: string,
+  createdBy: string,
+  overrides: Record<string, unknown> = {}
+) {
+  const { data, error } = await admin
+    .from('invitations')
+    .insert({ network_id: networkId, created_by: createdBy, ...overrides })
+    .select('id, token')
+    .single()
+  if (error) throw new Error(`seedInvitation failed: ${error.message}`)
+  return { id: data.id as string, token: data.token as string }
+}
+
 /** Seed a spot + spot_networks entry via admin */
 export async function seedSpot(
   authorId: string,

--- a/app/tests/integration/invitations/lifecycle.test.ts
+++ b/app/tests/integration/invitations/lifecycle.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Invitation lifecycle — Cycles I1–I11
+ *
+ * Verifies RLS + schema + RPCs support the full invitation lifecycle:
+ * generate, join (valid/idempotent), reject (expired/revoked/not-found),
+ * revoke (owner only), and public token lookup.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import {
+  createUser,
+  signIn,
+  cleanupUsers,
+  seedNetwork,
+  seedMembership,
+  seedInvitation,
+  anonClient,
+  admin,
+} from '../helpers/seed'
+
+// ---------------------------------------------------------------------------
+// Shared test principals
+// ---------------------------------------------------------------------------
+let ownerId: string
+let memberId: string
+let outsiderId: string
+let ownerClient: SupabaseClient
+let memberClient: SupabaseClient
+let outsiderClient: SupabaseClient
+let networkId: string
+
+beforeAll(async () => {
+  const owner = await createUser('inv-lc-owner')
+  const member = await createUser('inv-lc-member')
+  const outsider = await createUser('inv-lc-outsider')
+
+  ownerId = owner.id
+  memberId = member.id
+  outsiderId = outsider.id
+
+  ownerClient = await signIn(owner.email, owner.password)
+  memberClient = await signIn(member.email, member.password)
+  outsiderClient = await signIn(outsider.email, outsider.password)
+
+  networkId = await seedNetwork(ownerId, 'Invite Test Network')
+  await seedMembership(memberId, networkId, 'member')
+})
+
+afterAll(async () => {
+  await cleanupUsers([ownerId, memberId, outsiderId])
+})
+
+// ---------------------------------------------------------------------------
+// Cycle I1: Member can create an invitation (RLS allows)
+// ---------------------------------------------------------------------------
+describe('I1: Member creates an invitation', () => {
+  it('member can insert an invitation for their network', async () => {
+    const { data, error } = await memberClient
+      .from('invitations')
+      .insert({ network_id: networkId, created_by: memberId })
+      .select('id, token, expires_at, revoked_at')
+      .single()
+
+    expect(error).toBeNull()
+    expect(data?.token).toBeTruthy()
+    expect(data?.revoked_at).toBeNull()
+    expect(new Date(data!.expires_at).getTime()).toBeGreaterThan(Date.now())
+
+    await admin.from('invitations').delete().eq('id', data!.id)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cycle I2: Non-member cannot create an invitation (RLS blocks)
+// ---------------------------------------------------------------------------
+describe('I2: Non-member cannot create an invitation', () => {
+  it('outsider insert is blocked by RLS', async () => {
+    const { error } = await outsiderClient
+      .from('invitations')
+      .insert({ network_id: networkId, created_by: outsiderId })
+      .select('id')
+      .single()
+
+    expect(error).not.toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cycle I3–I6: lookup_invitation RPC returns correct status
+// ---------------------------------------------------------------------------
+describe('I3: lookup_invitation returns valid for a fresh token', () => {
+  it('anon client can call lookup_invitation with valid token', async () => {
+    const { token } = await seedInvitation(networkId, ownerId)
+    const anon = anonClient()
+    const { data, error } = await anon.rpc('lookup_invitation', { p_token: token })
+
+    expect(error).toBeNull()
+    const row = data?.[0]
+    expect(row?.status).toBe('valid')
+    expect(row?.network_name).toBe('Invite Test Network')
+    expect(row?.network_id).toBe(networkId)
+
+    await admin.from('invitations').delete().match({ network_id: networkId, token })
+  })
+})
+
+describe('I4: lookup_invitation returns expired for past-expiry token', () => {
+  it('returns expired status', async () => {
+    const { token } = await seedInvitation(networkId, ownerId, {
+      expires_at: new Date(Date.now() - 1000).toISOString(),
+    })
+    const anon = anonClient()
+    const { data } = await anon.rpc('lookup_invitation', { p_token: token })
+
+    expect(data?.[0]?.status).toBe('expired')
+
+    await admin.from('invitations').delete().match({ network_id: networkId, token })
+  })
+})
+
+describe('I5: lookup_invitation returns revoked for revoked token', () => {
+  it('returns revoked status', async () => {
+    const { id, token } = await seedInvitation(networkId, ownerId)
+    await admin
+      .from('invitations')
+      .update({ revoked_at: new Date().toISOString() })
+      .eq('id', id)
+
+    const anon = anonClient()
+    const { data } = await anon.rpc('lookup_invitation', { p_token: token })
+
+    expect(data?.[0]?.status).toBe('revoked')
+
+    await admin.from('invitations').delete().eq('id', id)
+  })
+})
+
+describe('I6: lookup_invitation returns not_found for unknown token', () => {
+  it('returns not_found for a nonexistent token', async () => {
+    const anon = anonClient()
+    const { data } = await anon.rpc('lookup_invitation', { p_token: 'doesnotexist0000' })
+
+    expect(data?.[0]?.status).toBe('not_found')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cycle I7: join_by_token inserts membership for a valid token
+// ---------------------------------------------------------------------------
+describe('I7: join_by_token succeeds for valid token', () => {
+  let joiner: SupabaseClient
+  let joinerId: string
+  let token: string
+  let invitationId: string
+
+  beforeAll(async () => {
+    const u = await createUser('inv-joiner')
+    joinerId = u.id
+    joiner = await signIn(u.email, u.password)
+    const inv = await seedInvitation(networkId, ownerId)
+    token = inv.token
+    invitationId = inv.id
+  })
+
+  afterAll(async () => {
+    await admin.from('memberships').delete().eq('user_id', joinerId).eq('network_id', networkId)
+    await admin.from('invitations').delete().eq('id', invitationId)
+    await cleanupUsers([joinerId])
+  })
+
+  it('returns network_id and inserts membership', async () => {
+    const { data, error } = await joiner.rpc('join_by_token', { p_token: token })
+
+    expect(error).toBeNull()
+    expect(data).toBe(networkId)
+
+    const { data: mem } = await admin
+      .from('memberships')
+      .select('role')
+      .eq('user_id', joinerId)
+      .eq('network_id', networkId)
+      .single()
+
+    expect(mem?.role).toBe('member')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cycle I8: join_by_token is idempotent (already a member)
+// ---------------------------------------------------------------------------
+describe('I8: join_by_token is idempotent for existing member', () => {
+  let token: string
+  let invitationId: string
+
+  beforeAll(async () => {
+    const inv = await seedInvitation(networkId, ownerId)
+    token = inv.token
+    invitationId = inv.id
+  })
+
+  afterAll(async () => {
+    await admin.from('invitations').delete().eq('id', invitationId)
+  })
+
+  it('does not error when already a member (ON CONFLICT DO NOTHING)', async () => {
+    // ownerClient is already a member
+    const { data, error } = await ownerClient.rpc('join_by_token', { p_token: token })
+
+    expect(error).toBeNull()
+    expect(data).toBe(networkId)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cycle I9: join_by_token raises exception for expired token
+// ---------------------------------------------------------------------------
+describe('I9: join_by_token rejects expired token', () => {
+  let token: string
+  let invitationId: string
+
+  beforeAll(async () => {
+    const inv = await seedInvitation(networkId, ownerId, {
+      expires_at: new Date(Date.now() - 1000).toISOString(),
+    })
+    token = inv.token
+    invitationId = inv.id
+  })
+
+  afterAll(async () => {
+    await admin.from('invitations').delete().eq('id', invitationId)
+  })
+
+  it('returns an error for expired token', async () => {
+    const { error } = await memberClient.rpc('join_by_token', { p_token: token })
+    expect(error).not.toBeNull()
+    expect(error?.message).toMatch(/expired/i)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cycle I10: join_by_token raises exception for revoked token
+// ---------------------------------------------------------------------------
+describe('I10: join_by_token rejects revoked token', () => {
+  let token: string
+  let invitationId: string
+
+  beforeAll(async () => {
+    const inv = await seedInvitation(networkId, ownerId)
+    token = inv.token
+    invitationId = inv.id
+    await admin
+      .from('invitations')
+      .update({ revoked_at: new Date().toISOString() })
+      .eq('id', invitationId)
+  })
+
+  afterAll(async () => {
+    await admin.from('invitations').delete().eq('id', invitationId)
+  })
+
+  it('returns an error for revoked token', async () => {
+    const { error } = await memberClient.rpc('join_by_token', { p_token: token })
+    expect(error).not.toBeNull()
+    expect(error?.message).toMatch(/revoked/i)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cycle I11: Owner can revoke; member cannot (RLS blocks UPDATE)
+// ---------------------------------------------------------------------------
+describe('I11: Owner can revoke; member cannot', () => {
+  let invId: string
+
+  beforeAll(async () => {
+    const inv = await seedInvitation(networkId, ownerId)
+    invId = inv.id
+  })
+
+  afterAll(async () => {
+    await admin.from('invitations').delete().eq('id', invId)
+  })
+
+  it('member cannot revoke an invitation (RLS blocks)', async () => {
+    const { data, error } = await memberClient
+      .from('invitations')
+      .update({ revoked_at: new Date().toISOString() })
+      .eq('id', invId)
+      .select('revoked_at')
+
+    expect(error).toBeNull()
+    // RLS silently returns 0 rows
+    expect(data).toHaveLength(0)
+
+    const { data: inv } = await admin
+      .from('invitations')
+      .select('revoked_at')
+      .eq('id', invId)
+      .single()
+    expect(inv?.revoked_at).toBeNull()
+  })
+
+  it('owner can revoke an invitation', async () => {
+    const { data, error } = await ownerClient
+      .from('invitations')
+      .update({ revoked_at: new Date().toISOString() })
+      .eq('id', invId)
+      .select('revoked_at')
+      .single()
+
+    expect(error).toBeNull()
+    expect(data?.revoked_at).not.toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- Added `lookup_invitation` (anon-callable) and `join_by_token` (auth-required) security-definer RPCs
- Public `/invite/[token]` page handles all token states: valid → join UI, expired/revoked → clear message, unauthenticated → redirect to `/register?token=…`
- Register page auto-joins the inviting network after signup when a token is in the URL
- Network detail page: any member can generate invite links; owner can revoke active ones
- Middleware proxy allows `/invite/*` without authentication

## Closes
#5

## Human QA steps

**Generate an invite link**
- [x] Log in as any network member, go to `/networks/{id}`
- [x] Click "Generate invite link" — a URL appears on the page

**Unauthenticated join → register → auto-join**
- [x] Copy the invite URL, open in an incognito window
- [x] Expect: redirected to `/register?token=…`
- [x] Fill in username, email, password and submit
- [x] Expect: redirected to the network page and the new user appears in the member list

**Authenticated join**
- [x] Log in as a user who is not yet a member of the network
- [x] Visit the invite URL directly
- [x] Expect: page shows "You're invited to join [Network Name]" with a "Join Network" button
- [x] Click "Join Network"
- [x] Expect: redirected to the network page and the user appears in the member list

**Revoke an invite**
- [x] Log in as the network owner, go to `/networks/{id}`
- [x] Click "Revoke" next to an active invite link
- [x] Expect: that invite disappears from the active invites list
- [x] Visit the revoked invite URL
- [x] Expect: page shows "This invitation has been revoked."

**Expired invite**
- [x] In the database, set `expires_at` to a past timestamp for any invitation
- [x] Visit that invite URL
- [x] Expect: page shows "This invitation has expired."

**Invalid token**
- [x] Visit `/invite/nonsensetoken`
- [x] Expect: page shows "Invalid invitation link."