### PR TITLE
feat: drop pin spot creation

### DIFF
--- a/app/src/app/actions/spots.ts
+++ b/app/src/app/actions/spots.ts
@@ -1,0 +1,97 @@
+'use server'
+
+import { createSupabaseServerClient } from '@/lib/supabase/server'
+
+export interface CreatedSpot {
+  id: string
+  title: string
+  lat: number
+  lng: number
+  spot_networks: { network_id: string }[]
+}
+
+export type SpotActionResult =
+  | { spot: CreatedSpot; error?: never }
+  | { error: string; spot?: never }
+
+// ---------------------------------------------------------------------------
+// Reverse-geocode lat/lng → US state name via Nominatim (best-effort).
+// Returns null on any error — the state field is optional.
+// ---------------------------------------------------------------------------
+async function reverseGeocode(lat: number, lng: number): Promise<string | null> {
+  try {
+    const url = `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lng}&addressdetails=1`
+    const res = await fetch(url, {
+      headers: { 'User-Agent': 'TheSpot/1.0 (contact@thespot.app)' },
+      signal: AbortSignal.timeout(4000),
+    })
+    if (!res.ok) return null
+    const json = await res.json()
+    return (json?.address?.state as string | undefined) ?? null
+  } catch {
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Extract #hashtag words from a description string.
+// Returns lowercase strings with no duplicates.
+// ---------------------------------------------------------------------------
+function extractTags(text: string | null | undefined): string[] {
+  if (!text) return []
+  const matches = text.match(/#([a-z0-9][a-z0-9-]*)/gi) ?? []
+  return [...new Set(matches.map((t) => t.slice(1).toLowerCase()))]
+}
+
+// ---------------------------------------------------------------------------
+// createSpotAction — called directly (not via useActionState) from client.
+// Performs Nominatim geocoding, then calls create_spot RPC.
+// Media upload is handled client-side after this returns.
+// ---------------------------------------------------------------------------
+export async function createSpotAction(formData: FormData): Promise<SpotActionResult> {
+  const supabase = await createSupabaseServerClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return { error: 'Not authenticated.' }
+
+  const title = (formData.get('title') as string | null)?.trim()
+  if (!title) return { error: 'Title is required.' }
+
+  const lat = parseFloat(formData.get('lat') as string)
+  const lng = parseFloat(formData.get('lng') as string)
+  if (isNaN(lat) || isNaN(lng)) return { error: 'Invalid coordinates.' }
+
+  const date = (formData.get('date') as string | null) ?? new Date().toISOString().split('T')[0]
+  const description = (formData.get('description') as string | null)?.trim() || null
+  const networkIds = formData.getAll('networks') as string[]
+
+  if (networkIds.length === 0) return { error: 'At least one network is required.' }
+
+  const tagNames = extractTags(description)
+  const state = await reverseGeocode(lat, lng)
+
+  const { data: spotId, error: rpcError } = await supabase.rpc('create_spot', {
+    p_title: title,
+    p_description: description,
+    p_lat: lat,
+    p_lng: lng,
+    p_state: state,
+    p_date: date,
+    p_network_ids: networkIds,
+    p_tag_names: tagNames,
+  })
+
+  if (rpcError) return { error: rpcError.message }
+
+  return {
+    spot: {
+      id: spotId as string,
+      title,
+      lat,
+      lng,
+      spot_networks: networkIds.map((network_id) => ({ network_id })),
+    },
+  }
+}

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -1,6 +1,8 @@
 @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400;1,600&family=Source+Serif+4:ital,wght@0,300;0,400;0,600;1,300;1,400&display=swap');
 
 :root {
+  --radius: 3px;
+
   --paper: #FAF8F3;
   --ink: #2C2416;
   --ink-faint: #9A8C78;
@@ -63,6 +65,10 @@ body {
   box-sizing: border-box;
   padding: 0;
   margin: 0;
+}
+
+button, input, textarea, select {
+  border-radius: var(--radius);
 }
 
 a {

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -4,14 +4,17 @@ import MapPage from '@/components/map/MapPage'
 export default async function Home() {
   const supabase = await createSupabaseServerClient()
 
-  const [{ data: spots }, { data: networks }] = await Promise.all([
+  const [{ data: spots }, { data: networks }, { data: { user } }] = await Promise.all([
     supabase.from('spots').select('id, title, lat, lng, spot_networks(network_id)'),
     supabase.from('networks').select('id, name').order('name'),
+    supabase.auth.getUser(),
   ])
+
+  const username = user?.user_metadata?.username ?? user?.email ?? 'Unknown'
 
   return (
     <main style={{ height: '100vh', overflow: 'hidden' }}>
-      <MapPage spots={spots ?? []} networks={networks ?? []} />
+      <MapPage spots={spots ?? []} networks={networks ?? []} username={username} />
     </main>
   )
 }

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -4,17 +4,14 @@ import MapPage from '@/components/map/MapPage'
 export default async function Home() {
   const supabase = await createSupabaseServerClient()
 
-  const [{ data: spots }, { data: networks }, { data: { user } }] = await Promise.all([
+  const [{ data: spots }, { data: networks }] = await Promise.all([
     supabase.from('spots').select('id, title, lat, lng, spot_networks(network_id)'),
     supabase.from('networks').select('id, name').order('name'),
-    supabase.auth.getUser(),
   ])
-
-  const username = user?.user_metadata?.username ?? user?.email ?? 'Unknown'
 
   return (
     <main style={{ height: '100vh', overflow: 'hidden' }}>
-      <MapPage spots={spots ?? []} networks={networks ?? []} username={username} />
+      <MapPage spots={spots ?? []} networks={networks ?? []} />
     </main>
   )
 }

--- a/app/src/components/map/MapPage.tsx
+++ b/app/src/components/map/MapPage.tsx
@@ -1,9 +1,12 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import dynamic from 'next/dynamic'
 import NetworkFilter from './NetworkFilter'
+import SpotCreationForm from './SpotCreationForm'
+import type { CreatedSpot } from '@/app/actions/spots'
 import styles from './map.module.css'
+import formStyles from './spotCreationForm.module.css'
 
 const MapView = dynamic(() => import('./MapView'), {
   ssr: false,
@@ -29,19 +32,75 @@ interface Network {
   name: string
 }
 
+interface LatLng {
+  lat: number
+  lng: number
+}
+
 interface MapPageProps {
   spots: Spot[]
   networks: Network[]
+  username: string
 }
 
-export default function MapPage({ spots, networks }: MapPageProps) {
+export default function MapPage({ spots: initialSpots, networks, username }: MapPageProps) {
   const [selectedNetworkId, setSelectedNetworkId] = useState<string | null>(null)
   const [panelOpen, setPanelOpen] = useState(false)
+  const [liveSpots, setLiveSpots] = useState<Spot[]>(initialSpots)
+  const [dropMode, setDropMode] = useState(false)
+  const [provisionalPin, setProvisionalPin] = useState<LatLng | null>(null)
+  const [formOpen, setFormOpen] = useState(false)
+  const [droppedLatLng, setDroppedLatLng] = useState<LatLng | null>(null)
+
+  // Esc exits drop mode
+  useEffect(() => {
+    if (!dropMode) return
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') exitDropMode()
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dropMode])
+
+  function enterDropMode() {
+    setDropMode(true)
+    setPanelOpen(false)
+  }
+
+  function exitDropMode() {
+    setDropMode(false)
+    setProvisionalPin(null)
+    setFormOpen(false)
+    setDroppedLatLng(null)
+  }
+
+  const handleDrop = useCallback((latlng: LatLng) => {
+    setProvisionalPin(latlng)
+    setDroppedLatLng(latlng)
+    setDropMode(false)
+    setFormOpen(true)
+  }, [])
+
+  function handleSave(spot: CreatedSpot) {
+    setLiveSpots((prev) => [...prev, spot])
+    setProvisionalPin(null)
+    setFormOpen(false)
+    setDroppedLatLng(null)
+    setDropMode(false)
+  }
+
+  function handleCancel() {
+    setProvisionalPin(null)
+    setFormOpen(false)
+    setDroppedLatLng(null)
+    setDropMode(false)
+  }
 
   const visibleSpots =
     selectedNetworkId === null
-      ? spots
-      : spots.filter((s) =>
+      ? liveSpots
+      : liveSpots.filter((s) =>
           s.spot_networks.some((sn) => sn.network_id === selectedNetworkId)
         )
 
@@ -70,8 +129,48 @@ export default function MapPage({ spots, networks }: MapPageProps) {
       </aside>
 
       <div className={styles.mapWrap}>
-        <MapView spots={visibleSpots} />
+        {/* Drop mode banner */}
+        {dropMode && (
+          <div className={formStyles.dropBanner} role="status">
+            <span>Click the map to place your spot — Esc to cancel</span>
+            <button
+              type="button"
+              className={formStyles.dropBannerClose}
+              onClick={exitDropMode}
+              aria-label="Cancel drop mode"
+            >
+              ×
+            </button>
+          </div>
+        )}
+
+        {/* Add Spot button */}
+        <button
+          type="button"
+          className={`${formStyles.addSpotBtn} ${dropMode ? formStyles.addSpotBtnActive : ''}`}
+          onClick={dropMode ? exitDropMode : enterDropMode}
+          aria-label={dropMode ? 'Cancel adding spot' : 'Add a new spot'}
+          aria-pressed={dropMode}
+        >
+          + Add Spot
+        </button>
+
+        <MapView
+          spots={visibleSpots}
+          dropMode={dropMode}
+          provisionalPin={provisionalPin}
+          onDrop={handleDrop}
+        />
       </div>
+
+      <SpotCreationForm
+        open={formOpen}
+        latlng={droppedLatLng}
+        networks={networks}
+        username={username}
+        onSave={handleSave}
+        onCancel={handleCancel}
+      />
     </div>
   )
 }

--- a/app/src/components/map/MapPage.tsx
+++ b/app/src/components/map/MapPage.tsx
@@ -129,7 +129,14 @@ export default function MapPage({ spots: initialSpots, networks, username }: Map
       </aside>
 
       <div className={styles.mapWrap}>
-        {/* Drop mode banner */}
+        <MapView
+          spots={visibleSpots}
+          dropMode={dropMode}
+          provisionalPin={provisionalPin}
+          onDrop={handleDrop}
+        />
+
+        {/* Drop mode banner — rendered after MapView so it sits above in DOM */}
         {dropMode && (
           <div className={formStyles.dropBanner} role="status">
             <span>Click the map to place your spot — Esc to cancel</span>
@@ -154,13 +161,6 @@ export default function MapPage({ spots: initialSpots, networks, username }: Map
         >
           + Add Spot
         </button>
-
-        <MapView
-          spots={visibleSpots}
-          dropMode={dropMode}
-          provisionalPin={provisionalPin}
-          onDrop={handleDrop}
-        />
       </div>
 
       <SpotCreationForm

--- a/app/src/components/map/MapPage.tsx
+++ b/app/src/components/map/MapPage.tsx
@@ -40,10 +40,9 @@ interface LatLng {
 interface MapPageProps {
   spots: Spot[]
   networks: Network[]
-  username: string
 }
 
-export default function MapPage({ spots: initialSpots, networks, username }: MapPageProps) {
+export default function MapPage({ spots: initialSpots, networks }: MapPageProps) {
   const [selectedNetworkId, setSelectedNetworkId] = useState<string | null>(null)
   const [panelOpen, setPanelOpen] = useState(false)
   const [liveSpots, setLiveSpots] = useState<Spot[]>(initialSpots)
@@ -135,39 +134,38 @@ export default function MapPage({ spots: initialSpots, networks, username }: Map
           provisionalPin={provisionalPin}
           onDrop={handleDrop}
         />
-
-        {/* Drop mode banner — rendered after MapView so it sits above in DOM */}
-        {dropMode && (
-          <div className={formStyles.dropBanner} role="status">
-            <span>Click the map to place your spot — Esc to cancel</span>
-            <button
-              type="button"
-              className={formStyles.dropBannerClose}
-              onClick={exitDropMode}
-              aria-label="Cancel drop mode"
-            >
-              ×
-            </button>
-          </div>
-        )}
-
-        {/* Add Spot button */}
-        <button
-          type="button"
-          className={`${formStyles.addSpotBtn} ${dropMode ? formStyles.addSpotBtnActive : ''}`}
-          onClick={dropMode ? exitDropMode : enterDropMode}
-          aria-label={dropMode ? 'Cancel adding spot' : 'Add a new spot'}
-          aria-pressed={dropMode}
-        >
-          + Add Spot
-        </button>
       </div>
+
+      {/* Drop mode banner — at layout level, outside mapWrap stacking context */}
+      {dropMode && (
+        <div className={formStyles.dropBanner} role="status">
+          <span>Click the map to place your spot — Esc to cancel</span>
+          <button
+            type="button"
+            className={formStyles.dropBannerClose}
+            onClick={exitDropMode}
+            aria-label="Cancel drop mode"
+          >
+            ×
+          </button>
+        </div>
+      )}
+
+      {/* Add Spot button — at layout level, outside mapWrap stacking context */}
+      <button
+        type="button"
+        className={`${formStyles.addSpotBtn} ${dropMode ? formStyles.addSpotBtnActive : ''}`}
+        onClick={dropMode ? exitDropMode : enterDropMode}
+        aria-label={dropMode ? 'Cancel adding spot' : 'Add a new spot'}
+        aria-pressed={dropMode}
+      >
+        + Add Spot
+      </button>
 
       <SpotCreationForm
         open={formOpen}
         latlng={droppedLatLng}
         networks={networks}
-        username={username}
         onSave={handleSave}
         onCancel={handleCancel}
       />

--- a/app/src/components/map/MapPage.tsx
+++ b/app/src/components/map/MapPage.tsx
@@ -45,6 +45,7 @@ interface MapPageProps {
 export default function MapPage({ spots: initialSpots, networks }: MapPageProps) {
   const [selectedNetworkId, setSelectedNetworkId] = useState<string | null>(null)
   const [panelOpen, setPanelOpen] = useState(false)
+  const [panelFullyClosed, setPanelFullyClosed] = useState(true)
   const [liveSpots, setLiveSpots] = useState<Spot[]>(initialSpots)
   const [dropMode, setDropMode] = useState(false)
   const [provisionalPin, setProvisionalPin] = useState<LatLng | null>(null)
@@ -64,7 +65,8 @@ export default function MapPage({ spots: initialSpots, networks }: MapPageProps)
 
   function enterDropMode() {
     setDropMode(true)
-    setPanelOpen(false)
+    if (panelOpen) setPanelOpen(false)
+    // panelFullyClosed will be set true via onTransitionEnd
   }
 
   function exitDropMode() {
@@ -105,17 +107,33 @@ export default function MapPage({ spots: initialSpots, networks }: MapPageProps)
 
   return (
     <div className={styles.layout}>
-      <button
-        className={styles.menuBtn}
-        onClick={() => setPanelOpen((v) => !v)}
-        aria-label="Toggle network panel"
-      >
-        ☰
-      </button>
+      {/* Fixed button on map — shown only after panel fully slides out */}
+      {panelFullyClosed && (
+        <button
+          className={styles.menuBtn}
+          onClick={() => { setPanelOpen(true); setPanelFullyClosed(false) }}
+          aria-label="Open network panel"
+        >
+          ☰
+        </button>
+      )}
 
-      <aside className={`${styles.panel} ${panelOpen ? styles.panelOpen : ''}`}>
+      <aside
+        className={`${styles.panel} ${panelOpen ? styles.panelOpen : ''}`}
+        onTransitionEnd={(e) => {
+          if (e.propertyName === 'transform' && !panelOpen) setPanelFullyClosed(true)
+        }}
+      >
         <div className={styles.panelHeader}>
           <span className={styles.panelTitle}>The Spot</span>
+          {/* Inline button inside panel header — visible when panel is open */}
+          <button
+            className={styles.menuBtn}
+            onClick={() => setPanelOpen(false)}
+            aria-label="Close network panel"
+          >
+            ☰
+          </button>
         </div>
         <div className={styles.panelSection}>
           <p className={styles.panelLabel}>Networks</p>

--- a/app/src/components/map/MapView.tsx
+++ b/app/src/components/map/MapView.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet'
+import { useEffect, useState, useCallback } from 'react'
+import { MapContainer, TileLayer, Marker, Popup, useMapEvents } from 'react-leaflet'
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 
@@ -17,8 +17,16 @@ interface Spot {
   spot_networks: SpotNetwork[]
 }
 
+interface LatLng {
+  lat: number
+  lng: number
+}
+
 interface MapViewProps {
   spots: Spot[]
+  dropMode: boolean
+  provisionalPin: LatLng | null
+  onDrop: (latlng: LatLng) => void
 }
 
 const OSM_TILE = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
@@ -28,11 +36,20 @@ const STADIA_DARK_TILE = 'https://tiles.stadiamaps.com/tiles/alidade_smooth_dark
 const STADIA_DARK_ATTRIBUTION =
   '&copy; <a href="https://stadiamaps.com/">Stadia Maps</a>, &copy; <a href="https://openmaptiles.org/">OpenMapTiles</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
 
-function makePinIcon(active = false): L.DivIcon {
-  const fill = active ? 'var(--accent)' : 'var(--sepia)'
+function makePinIcon(variant: 'saved' | 'active' | 'provisional'): L.DivIcon {
+  const fill =
+    variant === 'active' ? 'var(--accent)' :
+    variant === 'provisional' ? 'none' :
+    'var(--sepia)'
+  const stroke = variant === 'provisional' ? 'var(--tan)' : 'none'
+  const strokeDasharray = variant === 'provisional' ? '4 3' : 'none'
+  const dotFill = variant === 'provisional' ? 'none' : 'white'
+  const dotOpacity = variant === 'provisional' ? '0' : '0.6'
+
   const svg = `<svg viewBox="0 0 24 32" width="24" height="32" xmlns="http://www.w3.org/2000/svg">
-    <path d="M12 0C6.477 0 2 4.477 2 10c0 7 10 22 10 22S22 17 22 10C22 4.477 17.523 0 12 0z" fill="${fill}"/>
-    <circle cx="12" cy="10" r="4" fill="white" fill-opacity="0.6"/>
+    <path d="M12 0C6.477 0 2 4.477 2 10c0 7 10 22 10 22S22 17 22 10C22 4.477 17.523 0 12 0z"
+      fill="${fill}" stroke="${stroke}" stroke-width="1.5" stroke-dasharray="${strokeDasharray}"/>
+    <circle cx="12" cy="10" r="4" fill="${dotFill}" fill-opacity="${dotOpacity}"/>
   </svg>`
 
   return L.divIcon({
@@ -51,7 +68,25 @@ function centroid(spots: Spot[]): [number, number] {
   return [lat, lng]
 }
 
-export default function MapView({ spots }: MapViewProps) {
+// Manages cursor and click events inside the Leaflet context
+function DropHandler({ dropMode, onDrop }: { dropMode: boolean; onDrop: (latlng: LatLng) => void }) {
+  const map = useMapEvents({
+    click(e) {
+      if (dropMode) {
+        onDrop({ lat: e.latlng.lat, lng: e.latlng.lng })
+      }
+    },
+  })
+
+  useEffect(() => {
+    const container = map.getContainer()
+    container.style.cursor = dropMode ? 'crosshair' : ''
+  }, [dropMode, map])
+
+  return null
+}
+
+export default function MapView({ spots, dropMode, provisionalPin, onDrop }: MapViewProps) {
   const [dark, setDark] = useState(false)
 
   useEffect(() => {
@@ -62,6 +97,7 @@ export default function MapView({ spots }: MapViewProps) {
     return () => mq.removeEventListener('change', handler)
   }, [])
 
+  const handleDrop = useCallback(onDrop, [onDrop])
   const center = centroid(spots)
 
   return (
@@ -71,11 +107,20 @@ export default function MapView({ spots }: MapViewProps) {
         url={dark ? STADIA_DARK_TILE : OSM_TILE}
         attribution={dark ? STADIA_DARK_ATTRIBUTION : OSM_ATTRIBUTION}
       />
+      <DropHandler dropMode={dropMode} onDrop={handleDrop} />
       {spots.map((spot) => (
-        <Marker key={spot.id} position={[spot.lat, spot.lng]} icon={makePinIcon()}>
+        <Marker key={spot.id} position={[spot.lat, spot.lng]} icon={makePinIcon('saved')}>
           <Popup>{spot.title}</Popup>
         </Marker>
       ))}
+      {provisionalPin && (
+        <Marker
+          key="provisional"
+          position={[provisionalPin.lat, provisionalPin.lng]}
+          icon={makePinIcon('provisional')}
+          interactive={false}
+        />
+      )}
     </MapContainer>
   )
 }

--- a/app/src/components/map/SpotCreationForm.tsx
+++ b/app/src/components/map/SpotCreationForm.tsx
@@ -1,0 +1,416 @@
+'use client'
+
+import { useRef, useState, useEffect } from 'react'
+import { createSpotAction, type CreatedSpot } from '@/app/actions/spots'
+import { createSupabaseBrowserClient } from '@/lib/supabase/browser'
+import styles from './spotCreationForm.module.css'
+
+interface Network {
+  id: string
+  name: string
+}
+
+interface LatLng {
+  lat: number
+  lng: number
+}
+
+interface Props {
+  open: boolean
+  latlng: LatLng | null
+  networks: Network[]
+  username: string
+  onSave: (spot: CreatedSpot) => void
+  onCancel: () => void
+}
+
+const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp']
+const ALLOWED_AUDIO_TYPES = ['audio/mpeg', 'audio/wav', 'audio/mp4']
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024
+const MAX_AUDIO_BYTES = 20 * 1024 * 1024
+
+function formatDate(d: Date) {
+  return d.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+}
+
+function formatCoords(latlng: LatLng) {
+  const latStr = `${Math.abs(latlng.lat).toFixed(4)}° ${latlng.lat >= 0 ? 'N' : 'S'}`
+  const lngStr = `${Math.abs(latlng.lng).toFixed(4)}° ${latlng.lng >= 0 ? 'E' : 'W'}`
+  return `${latStr}, ${lngStr}`
+}
+
+export default function SpotCreationForm({
+  open,
+  latlng,
+  networks,
+  username,
+  onSave,
+  onCancel,
+}: Props) {
+  const formRef = useRef<HTMLFormElement>(null)
+  const titleRef = useRef<HTMLInputElement>(null)
+  const descRef = useRef<HTMLTextAreaElement>(null)
+
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [titleError, setTitleError] = useState(false)
+  const [networkError, setNetworkError] = useState(false)
+  const [dirty, setDirty] = useState(false)
+  const [showDiscard, setShowDiscard] = useState(false)
+  const [selectedNetworks, setSelectedNetworks] = useState<Set<string>>(new Set())
+  const [files, setFiles] = useState<File[]>([])
+  const [date] = useState(() => formatDate(new Date()))
+  const [isoDate] = useState(() => new Date().toISOString().split('T')[0])
+
+  // Reset form when opened
+  useEffect(() => {
+    if (open) {
+      setError(null)
+      setTitleError(false)
+      setNetworkError(false)
+      setDirty(false)
+      setShowDiscard(false)
+      setSelectedNetworks(new Set())
+      setFiles([])
+      // Focus title after slide-up animation
+      const t = setTimeout(() => titleRef.current?.focus(), 760)
+      return () => clearTimeout(t)
+    }
+  }, [open])
+
+  // Auto-grow textarea
+  function growDesc() {
+    const el = descRef.current
+    if (!el) return
+    el.style.height = 'auto'
+    el.style.height = el.scrollHeight + 'px'
+  }
+
+  function toggleNetwork(id: string) {
+    setSelectedNetworks((prev) => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
+    setDirty(true)
+    setNetworkError(false)
+  }
+
+  function handleFileChange(newFiles: FileList | null) {
+    if (!newFiles) return
+    const valid: File[] = []
+    for (const f of Array.from(newFiles)) {
+      const isImage = ALLOWED_IMAGE_TYPES.includes(f.type)
+      const isAudio = ALLOWED_AUDIO_TYPES.includes(f.type)
+      if (isImage && f.size <= MAX_IMAGE_BYTES) valid.push(f)
+      else if (isAudio && f.size <= MAX_AUDIO_BYTES) valid.push(f)
+    }
+    setFiles((prev) => [...prev, ...valid])
+    setDirty(true)
+  }
+
+  function removeFile(file: File) {
+    setFiles((prev) => prev.filter((f) => f !== file))
+  }
+
+  function attemptCancel() {
+    if (dirty) {
+      setShowDiscard(true)
+    } else {
+      onCancel()
+    }
+  }
+
+  async function uploadMedia(spotId: string) {
+    if (files.length === 0) return
+    const supabase = createSupabaseBrowserClient()
+    for (const file of files) {
+      const ext = file.name.split('.').pop() ?? 'bin'
+      const path = `${spotId}/${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`
+      const { error: storErr } = await supabase.storage.from('media').upload(path, file)
+      if (storErr) continue // best-effort; don't fail the save
+
+      const { data: urlData } = supabase.storage.from('media').getPublicUrl(path)
+      const type = ALLOWED_IMAGE_TYPES.includes(file.type) ? 'image' : 'audio'
+      await supabase.from('media').insert({ spot_id: spotId, url: urlData.publicUrl, type })
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    if (!latlng) return
+
+    const title = titleRef.current?.value.trim() ?? ''
+    if (!title) {
+      setTitleError(true)
+      titleRef.current?.focus()
+      return
+    }
+    if (selectedNetworks.size === 0) {
+      setNetworkError(true)
+      return
+    }
+
+    setPending(true)
+    setError(null)
+    setTitleError(false)
+    setNetworkError(false)
+
+    const fd = new FormData()
+    fd.set('title', title)
+    fd.set('description', descRef.current?.value ?? '')
+    fd.set('lat', String(latlng.lat))
+    fd.set('lng', String(latlng.lng))
+    fd.set('date', isoDate)
+    for (const nid of selectedNetworks) fd.append('networks', nid)
+
+    const result = await createSpotAction(fd)
+
+    if ('error' in result && result.error) {
+      setError(result.error)
+      setPending(false)
+      return
+    }
+
+    if (!('spot' in result) || !result.spot) {
+      setError('Unexpected error saving spot.')
+      setPending(false)
+      return
+    }
+
+    await uploadMedia(result.spot.id)
+
+    setPending(false)
+    onSave(result.spot)
+  }
+
+  if (!open) return null
+
+  return (
+    <div className={styles.overlay} role="dialog" aria-modal="true" aria-label="Create a new spot">
+      <button
+        className={styles.closeBtn}
+        onClick={attemptCancel}
+        aria-label="Cancel"
+        type="button"
+        disabled={pending}
+      >
+        ×
+      </button>
+
+      <form ref={formRef} onSubmit={handleSubmit} noValidate>
+        <div className={styles.inner}>
+          {/* ── Left: media upload ── */}
+          <div className={styles.mediaCol}>
+            <UploadZone files={files} onAdd={handleFileChange} onRemove={removeFile} />
+            {latlng && (
+              <p className={styles.coords}>{formatCoords(latlng)}</p>
+            )}
+          </div>
+
+          {/* ── Right: metadata ── */}
+          <div className={styles.metaCol}>
+            {/* Title */}
+            <input
+              ref={titleRef}
+              name="title"
+              type="text"
+              className={`${styles.title} ${titleError ? styles.titleError : ''}`}
+              placeholder="Name this spot…"
+              aria-label="Spot title"
+              autoComplete="off"
+              onChange={() => { setDirty(true); setTitleError(false) }}
+            />
+            {titleError && (
+              <p className={styles.fieldError}>A title is required to save.</p>
+            )}
+
+            {/* Description */}
+            <textarea
+              ref={descRef}
+              name="description"
+              className={styles.desc}
+              placeholder="Field notes, observations… use #words to tag this spot."
+              aria-label="Field notes"
+              rows={3}
+              onInput={growDesc}
+              onChange={() => setDirty(true)}
+            />
+
+            {/* Networks */}
+            <div className={styles.networksRow}>
+              <span className={styles.networksLabel}>Visible to</span>
+              <div className={styles.networkPills}>
+                {networks.map((n) => (
+                  <button
+                    key={n.id}
+                    type="button"
+                    className={`${styles.networkPill} ${selectedNetworks.has(n.id) ? styles.networkPillSelected : ''}`}
+                    onClick={() => toggleNetwork(n.id)}
+                  >
+                    {n.name}
+                  </button>
+                ))}
+              </div>
+            </div>
+            {networkError && (
+              <p className={styles.fieldError}>Select at least one network.</p>
+            )}
+
+            {/* Auto-fill: date + author */}
+            <div className={styles.autofill}>
+              <AutofillItem label="Date" value={date} />
+              <AutofillItem label="Author" value={username} />
+            </div>
+
+            {/* Discard banner */}
+            {showDiscard && (
+              <div className={styles.discardBanner} role="alert">
+                <span>Discard unsaved notes?</span>
+                <button type="button" className={styles.discardConfirm} onClick={onCancel}>
+                  Yes, discard
+                </button>
+                <button type="button" className={styles.discardKeep} onClick={() => setShowDiscard(false)}>
+                  Keep editing
+                </button>
+              </div>
+            )}
+
+            {/* Server error */}
+            {error && <p className={styles.serverError} role="alert">{error}</p>}
+
+            {/* Actions */}
+            <div className={styles.actions}>
+              <button type="submit" className={styles.btnPrimary} disabled={pending}>
+                {pending ? 'Saving…' : 'Save Spot'}
+              </button>
+              <button type="button" className={styles.btnGhost} onClick={attemptCancel} disabled={pending}>
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// AutofillItem — read-only field, editable on click
+// ---------------------------------------------------------------------------
+function AutofillItem({ label, value }: { label: string; value: string }) {
+  const [editable, setEditable] = useState(false)
+  return (
+    <div className={styles.autofillItem}>
+      <span className={styles.autofillLabel}>{label}</span>
+      <input
+        type="text"
+        className={styles.autofillValue}
+        defaultValue={value}
+        readOnly={!editable}
+        onFocus={() => setEditable(true)}
+        onBlur={() => setEditable(false)}
+        aria-label={label}
+      />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// UploadZone
+// ---------------------------------------------------------------------------
+interface UploadZoneProps {
+  files: File[]
+  onAdd: (files: FileList | null) => void
+  onRemove: (file: File) => void
+}
+
+function UploadZone({ files, onAdd, onRemove }: UploadZoneProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [dragging, setDragging] = useState(false)
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault()
+    setDragging(false)
+    onAdd(e.dataTransfer.files)
+  }
+
+  return (
+    <div
+      className={`${styles.uploadZone} ${dragging ? styles.uploadDragging : ''}`}
+      onClick={() => inputRef.current?.click()}
+      onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && inputRef.current?.click()}
+      onDragOver={(e) => { e.preventDefault(); setDragging(true) }}
+      onDragLeave={() => setDragging(false)}
+      onDrop={handleDrop}
+      role="button"
+      tabIndex={0}
+      aria-label="Upload photographs or sound files"
+    >
+      <span className={styles.cornerTL} />
+      <span className={styles.cornerTR} />
+      <span className={styles.cornerBL} />
+      <span className={styles.cornerBR} />
+      <div className={styles.dashedBorder} />
+
+      {files.length === 0 ? (
+        <div className={styles.uploadPlaceholder}>
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1">
+            <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/>
+            <circle cx="12" cy="13" r="4"/>
+          </svg>
+          <p className={styles.uploadLabel}>Attach photographs</p>
+          <p className={styles.uploadHint}>drag &amp; drop or click to browse</p>
+        </div>
+      ) : (
+        <div className={styles.thumbGrid} onClick={(e) => e.stopPropagation()}>
+          {files.map((file, i) => (
+            <div key={i} className={styles.thumbItem}>
+              {ALLOWED_IMAGE_TYPES.includes(file.type) ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={URL.createObjectURL(file)}
+                  alt={file.name}
+                  className={styles.thumbImg}
+                />
+              ) : (
+                <div className={styles.thumbAudio}>
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1">
+                    <path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/>
+                  </svg>
+                  <span>{file.name}</span>
+                </div>
+              )}
+              <button
+                type="button"
+                className={styles.thumbRemove}
+                aria-label={`Remove ${file.name}`}
+                onClick={(e) => { e.stopPropagation(); onRemove(file) }}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+          <button
+            type="button"
+            className={styles.addMoreBtn}
+            onClick={() => inputRef.current?.click()}
+            aria-label="Add more files"
+          >
+            +
+          </button>
+        </div>
+      )}
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/webp,audio/mpeg,audio/wav,audio/mp4"
+        multiple
+        style={{ display: 'none' }}
+        onChange={(e) => onAdd(e.target.files)}
+        onClick={(e) => e.stopPropagation()}
+      />
+    </div>
+  )
+}

--- a/app/src/components/map/SpotCreationForm.tsx
+++ b/app/src/components/map/SpotCreationForm.tsx
@@ -19,7 +19,6 @@ interface Props {
   open: boolean
   latlng: LatLng | null
   networks: Network[]
-  username: string
   onSave: (spot: CreatedSpot) => void
   onCancel: () => void
 }
@@ -43,7 +42,6 @@ export default function SpotCreationForm({
   open,
   latlng,
   networks,
-  username,
   onSave,
   onCancel,
 }: Props) {
@@ -52,6 +50,7 @@ export default function SpotCreationForm({
   const descRef = useRef<HTMLTextAreaElement>(null)
 
   const [pending, setPending] = useState(false)
+  const [exiting, setExiting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [titleError, setTitleError] = useState(false)
   const [networkError, setNetworkError] = useState(false)
@@ -121,6 +120,16 @@ export default function SpotCreationForm({
     }
   }
 
+  useEffect(() => {
+    if (!open) return
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') attemptCancel()
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, dirty])
+
   async function uploadMedia(spotId: string) {
     if (files.length === 0) return
     const supabase = createSupabaseBrowserClient()
@@ -181,13 +190,14 @@ export default function SpotCreationForm({
     await uploadMedia(result.spot.id)
 
     setPending(false)
-    onSave(result.spot)
+    setExiting(true)
+    setTimeout(() => onSave(result.spot), 750)
   }
 
   if (!open) return null
 
   return (
-    <div className={styles.overlay} role="dialog" aria-modal="true" aria-label="Create a new spot">
+    <div className={`${styles.overlay} ${exiting ? styles.overlayExiting : ''}`} role="dialog" aria-modal="true" aria-label="Create a new spot">
       <button
         className={styles.closeBtn}
         onClick={attemptCancel}
@@ -257,10 +267,9 @@ export default function SpotCreationForm({
               <p className={styles.fieldError}>Select at least one network.</p>
             )}
 
-            {/* Auto-fill: date + author */}
+            {/* Auto-fill: date */}
             <div className={styles.autofill}>
               <AutofillItem label="Date" value={date} />
-              <AutofillItem label="Author" value={username} />
             </div>
 
             {/* Discard banner */}
@@ -283,9 +292,6 @@ export default function SpotCreationForm({
             <div className={styles.actions}>
               <button type="submit" className={styles.btnPrimary} disabled={pending}>
                 {pending ? 'Saving…' : 'Save Spot'}
-              </button>
-              <button type="button" className={styles.btnGhost} onClick={attemptCancel} disabled={pending}>
-                Cancel
               </button>
             </div>
           </div>
@@ -360,7 +366,6 @@ function UploadZone({ files, onAdd, onRemove }: UploadZoneProps) {
             <circle cx="12" cy="13" r="4"/>
           </svg>
           <p className={styles.uploadLabel}>Attach photographs</p>
-          <p className={styles.uploadHint}>drag &amp; drop or click to browse</p>
         </div>
       ) : (
         <div className={styles.thumbGrid} onClick={(e) => e.stopPropagation()}>

--- a/app/src/components/map/map.module.css
+++ b/app/src/components/map/map.module.css
@@ -1,5 +1,5 @@
 .layout {
-  --panel-w: 300px; /* matches .panel width — used to centre dropBanner in mapWrap */
+  --panel-w: 0px; /* panel is always off-canvas; dropBanner centres in full viewport */
   position: relative;
   width: 100%;
   height: 100vh;
@@ -9,20 +9,33 @@
 
 /* ── Side Panel ── */
 .panel {
-  position: relative;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
   z-index: 1000;
   width: 300px;
-  flex-shrink: 0;
   display: flex;
   flex-direction: column;
   background: var(--panel-bg);
   border-right: 1px solid var(--rule);
   overflow-y: auto;
+  transform: translateX(-100%);
+  transition: transform 600ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .panelHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   padding: 24px 20px 12px;
   border-bottom: 1px solid var(--rule);
+}
+
+/* When menuBtn sits inside the panel header it must not be fixed */
+.panelHeader .menuBtn {
+  position: static;
+  flex-shrink: 0;
 }
 
 .panelTitle {
@@ -112,7 +125,7 @@
 }
 
 .menuBtn {
-  display: none;
+  display: flex;
   position: fixed;
   top: 12px;
   left: 12px;
@@ -128,27 +141,13 @@
   font-size: 1.2rem;
 }
 
+.panelOpen {
+  transform: translateX(0);
+}
+
 /* ── Mobile ── */
 @media (max-width: 580px) {
-  .layout {
-    --panel-w: 0px; /* panel is off-canvas; dropBanner centres in full viewport */
-  }
-
   .panel {
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
     width: 100%;
-    transform: translateX(-100%);
-    transition: transform 600ms cubic-bezier(0.4, 0, 0.2, 1);
-  }
-
-  .panelOpen {
-    transform: translateX(0);
-  }
-
-  .menuBtn {
-    display: flex;
   }
 }

--- a/app/src/components/map/map.module.css
+++ b/app/src/components/map/map.module.css
@@ -71,7 +71,6 @@
   text-align: left;
   padding: 8px 12px;
   border: 1px solid transparent;
-  border-radius: 3px;
   background: transparent;
   font-family: var(--font-body);
   font-size: 0.875rem;
@@ -123,7 +122,6 @@
   justify-content: center;
   background: var(--panel-bg);
   border: 1px solid var(--rule);
-  border-radius: 3px;
   cursor: pointer;
   color: var(--ink);
   font-size: 1.2rem;

--- a/app/src/components/map/map.module.css
+++ b/app/src/components/map/map.module.css
@@ -49,6 +49,7 @@
 .mapWrap {
   flex: 1;
   position: relative;
+  z-index: 1; /* stacking context boundary — keeps Leaflet panes from escaping */
 }
 
 .mapWrap :global(.leaflet-container) {

--- a/app/src/components/map/map.module.css
+++ b/app/src/components/map/map.module.css
@@ -71,6 +71,7 @@
   text-align: left;
   padding: 8px 12px;
   border: 1px solid transparent;
+  border-radius: 3px;
   background: transparent;
   font-family: var(--font-body);
   font-size: 0.875rem;
@@ -122,6 +123,7 @@
   justify-content: center;
   background: var(--panel-bg);
   border: 1px solid var(--rule);
+  border-radius: 3px;
   cursor: pointer;
   color: var(--ink);
   font-size: 1.2rem;

--- a/app/src/components/map/map.module.css
+++ b/app/src/components/map/map.module.css
@@ -1,4 +1,5 @@
 .layout {
+  --panel-w: 300px; /* matches .panel width — used to centre dropBanner in mapWrap */
   position: relative;
   width: 100%;
   height: 100vh;
@@ -112,10 +113,10 @@
 
 .menuBtn {
   display: none;
-  position: absolute;
+  position: fixed;
   top: 12px;
   left: 12px;
-  z-index: 1001;
+  z-index: 9000;
   width: 40px;
   height: 40px;
   align-items: center;
@@ -129,6 +130,10 @@
 
 /* ── Mobile ── */
 @media (max-width: 580px) {
+  .layout {
+    --panel-w: 0px; /* panel is off-canvas; dropBanner centres in full viewport */
+  }
+
   .panel {
     position: absolute;
     top: 0;

--- a/app/src/components/map/spotCreationForm.module.css
+++ b/app/src/components/map/spotCreationForm.module.css
@@ -5,7 +5,7 @@
   left: 0;
   right: 0;
   max-height: 72vh;
-  z-index: 300;
+  z-index: 8000;
   background: var(--modal-bg);
   border-top: 1px solid var(--rule);
   overflow-y: auto;
@@ -16,6 +16,15 @@
 @keyframes slideUp {
   from { transform: translateY(100%); }
   to   { transform: translateY(0); }
+}
+
+@keyframes slideDown {
+  from { transform: translateY(0); }
+  to   { transform: translateY(100%); }
+}
+
+.overlayExiting {
+  animation: slideDown 750ms cubic-bezier(0.4, 0, 0.2, 1) both;
 }
 
 /* ── Close button ── */
@@ -182,7 +191,8 @@
   background: var(--tan-light);
 }
 
-.networkPillSelected {
+.networkPillSelected,
+.networkPillSelected:hover {
   background: var(--ink);
   border-color: var(--ink);
   color: var(--paper);
@@ -497,10 +507,10 @@
 
 /* ── Add Spot button ── */
 .addSpotBtn {
-  position: absolute;
+  position: fixed;
   bottom: 28px;
   right: 24px;
-  z-index: 1001;
+  z-index: 500;
   font-family: var(--font-body);
   font-size: 0.72rem;
   font-weight: 300;
@@ -526,11 +536,11 @@
 
 /* ── Drop mode banner ── */
 .dropBanner {
-  position: absolute;
+  position: fixed;
   top: 12px;
-  left: 50%;
+  left: calc(50% + var(--panel-w) / 2); /* centres in mapWrap area; --panel-w from .layout */
   transform: translateX(-50%);
-  z-index: 1001;
+  z-index: 500;
   display: flex;
   align-items: center;
   gap: 10px;

--- a/app/src/components/map/spotCreationForm.module.css
+++ b/app/src/components/map/spotCreationForm.module.css
@@ -574,7 +574,7 @@
 @media (max-width: 580px) {
   .inner {
     grid-template-columns: 1fr;
-    padding: 20px 16px 28px;
+    padding: 52px 16px 28px; /* top clears the absolute-positioned closeBtn (top:12 + h:28 + gap:12) */
     gap: 16px;
   }
 

--- a/app/src/components/map/spotCreationForm.module.css
+++ b/app/src/components/map/spotCreationForm.module.css
@@ -531,7 +531,6 @@
   left: 50%;
   transform: translateX(-50%);
   z-index: 1001;
-  z-index: 200;
   display: flex;
   align-items: center;
   gap: 10px;

--- a/app/src/components/map/spotCreationForm.module.css
+++ b/app/src/components/map/spotCreationForm.module.css
@@ -1,0 +1,582 @@
+/* ── Overlay ── */
+.overlay {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  max-height: 72vh;
+  z-index: 300;
+  background: var(--modal-bg);
+  border-top: 1px solid var(--rule);
+  overflow-y: auto;
+  transform: translateY(0);
+  animation: slideUp 750ms cubic-bezier(0.4, 0, 0.2, 1) both;
+}
+
+@keyframes slideUp {
+  from { transform: translateY(100%); }
+  to   { transform: translateY(0); }
+}
+
+/* ── Close button ── */
+.closeBtn {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  z-index: 10;
+  width: 28px;
+  height: 28px;
+  background: transparent;
+  border: 1px solid var(--rule);
+  color: var(--ink-faint);
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.closeBtn:hover {
+  border-color: var(--sepia);
+  color: var(--ink);
+}
+
+/* ── Two-column inner grid ── */
+.inner {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  gap: 0;
+  padding: 28px 24px 28px 24px;
+  min-height: 100%;
+}
+
+/* ── Left: media column ── */
+.mediaCol {
+  padding-right: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.coords {
+  font-family: var(--font-body);
+  font-size: 0.68rem;
+  color: var(--ink-faint);
+  font-style: italic;
+  text-align: center;
+  letter-spacing: 0.03em;
+}
+
+/* ── Right: meta column ── */
+.metaCol {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-right: 36px; /* room for close btn */
+}
+
+/* ── Title ── */
+.title {
+  font-family: var(--font-serif);
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--ink);
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--rule);
+  outline: none;
+  width: 100%;
+  padding: 4px 0 6px;
+  letter-spacing: 0.01em;
+}
+
+.title::placeholder {
+  color: var(--ink-faint);
+  font-weight: 400;
+  font-style: italic;
+}
+
+.title:focus {
+  border-bottom-color: var(--accent);
+}
+
+.titleError {
+  border-bottom-color: #9B3A2A;
+}
+
+.fieldError {
+  font-family: var(--font-body);
+  font-size: 0.72rem;
+  color: #9B3A2A;
+  font-style: italic;
+  margin-top: -6px;
+}
+
+/* ── Description ── */
+.desc {
+  font-family: var(--font-body);
+  font-size: 0.9rem;
+  font-style: italic;
+  font-weight: 300;
+  color: var(--ink);
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--rule);
+  outline: none;
+  resize: none;
+  width: 100%;
+  padding: 4px 0 6px;
+  line-height: 1.6;
+  overflow: hidden;
+}
+
+.desc::placeholder {
+  color: var(--ink-faint);
+}
+
+.desc:focus {
+  border-bottom-color: var(--rule);
+}
+
+/* ── Networks row ── */
+.networksRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.networksLabel {
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink-faint);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.networkPills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.networkPill {
+  font-family: var(--font-body);
+  font-size: 0.72rem;
+  font-weight: 400;
+  letter-spacing: 0.06em;
+  padding: 3px 10px;
+  border: 1px solid var(--tan);
+  background: transparent;
+  color: var(--sepia);
+  cursor: pointer;
+  transition: background 150ms, color 150ms, border-color 150ms;
+}
+
+.networkPill:hover {
+  background: var(--tan-light);
+}
+
+.networkPillSelected {
+  background: var(--ink);
+  border-color: var(--ink);
+  color: var(--paper);
+}
+
+/* ── Autofill block ── */
+.autofill {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.autofillItem {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.autofillLabel {
+  font-family: var(--font-body);
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ink-faint);
+  width: 48px;
+  flex-shrink: 0;
+}
+
+.autofillValue {
+  font-family: var(--font-body);
+  font-size: 0.82rem;
+  font-style: italic;
+  color: var(--sepia);
+  background: transparent;
+  border: none;
+  outline: none;
+  border-bottom: 1px solid transparent;
+  padding: 1px 0;
+  flex: 1;
+  cursor: default;
+}
+
+.autofillValue:focus {
+  border-bottom-color: var(--rule);
+  color: var(--ink);
+  cursor: text;
+}
+
+/* ── Discard banner ── */
+.discardBanner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border: 1px solid var(--tan);
+  background: var(--tan-light);
+  font-family: var(--font-body);
+  font-size: 0.8rem;
+  font-style: italic;
+  color: var(--ink);
+  flex-wrap: wrap;
+}
+
+.discardConfirm {
+  font-family: var(--font-body);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  background: var(--ink);
+  color: var(--paper);
+  border: 1px solid var(--ink);
+  padding: 3px 10px;
+  cursor: pointer;
+}
+
+.discardKeep {
+  font-family: var(--font-body);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  background: transparent;
+  color: var(--ink);
+  border: 1px solid var(--rule);
+  padding: 3px 10px;
+  cursor: pointer;
+}
+
+/* ── Server error ── */
+.serverError {
+  font-family: var(--font-body);
+  font-size: 0.8rem;
+  font-style: italic;
+  color: #9B3A2A;
+}
+
+/* ── Actions ── */
+.actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  padding-top: 4px;
+}
+
+.btnPrimary {
+  font-family: var(--font-body);
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  padding: 8px 20px;
+  background: var(--ink);
+  color: var(--paper);
+  border: 1px solid var(--ink);
+  cursor: pointer;
+  transition: opacity 150ms;
+}
+
+.btnPrimary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btnGhost {
+  font-family: var(--font-body);
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  padding: 8px 20px;
+  background: transparent;
+  color: var(--ink);
+  border: 1px solid var(--rule);
+  cursor: pointer;
+  transition: border-color 150ms;
+}
+
+.btnGhost:hover {
+  border-color: var(--sepia);
+}
+
+.btnGhost:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── Upload zone ── */
+.uploadZone {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 3/4;
+  background: var(--panel-bg);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 8px;
+  outline: none;
+}
+
+.uploadZone:focus-visible {
+  outline: 2px solid var(--sepia);
+  outline-offset: 2px;
+}
+
+/* Corner ticks */
+.cornerTL,
+.cornerTR,
+.cornerBL,
+.cornerBR {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  pointer-events: none;
+}
+
+.cornerTL { top: 0; left: 0; border-top: 1px solid var(--tan); border-left: 1px solid var(--tan); }
+.cornerTR { top: 0; right: 0; border-top: 1px solid var(--tan); border-right: 1px solid var(--tan); }
+.cornerBL { bottom: 0; left: 0; border-bottom: 1px solid var(--tan); border-left: 1px solid var(--tan); }
+.cornerBR { bottom: 0; right: 0; border-bottom: 1px solid var(--tan); border-right: 1px solid var(--tan); }
+
+/* Dashed inner border */
+.dashedBorder {
+  position: absolute;
+  inset: 8px;
+  border: 1px dashed var(--tan);
+  pointer-events: none;
+}
+
+.uploadDragging .dashedBorder {
+  border-color: var(--accent);
+}
+
+.uploadPlaceholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  color: var(--ink-faint);
+  position: relative;
+  z-index: 1;
+}
+
+.uploadLabel {
+  font-family: var(--font-body);
+  font-size: 0.78rem;
+  font-style: italic;
+  letter-spacing: 0.04em;
+}
+
+.uploadHint {
+  font-family: var(--font-body);
+  font-size: 0.65rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  opacity: 0.7;
+}
+
+/* ── Thumbnail grid ── */
+.thumbGrid {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 6px;
+  padding: 16px;
+  width: 100%;
+  height: 100%;
+  overflow-y: auto;
+  align-content: start;
+}
+
+.thumbItem {
+  position: relative;
+  aspect-ratio: 3/4;
+  overflow: hidden;
+}
+
+.thumbImg {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.thumbAudio {
+  width: 100%;
+  height: 100%;
+  background: var(--tan-light);
+  border: 1px solid var(--rule);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  color: var(--ink-faint);
+  padding: 8px;
+  text-align: center;
+}
+
+.thumbAudio span {
+  font-family: var(--font-body);
+  font-size: 0.6rem;
+  font-style: italic;
+  word-break: break-all;
+  line-height: 1.3;
+}
+
+.thumbRemove {
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  width: 18px;
+  height: 18px;
+  background: var(--ink);
+  color: var(--paper);
+  border: none;
+  font-size: 0.85rem;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  opacity: 0.8;
+}
+
+.thumbRemove:hover {
+  opacity: 1;
+}
+
+.addMoreBtn {
+  aspect-ratio: 3/4;
+  background: var(--tan-light);
+  border: 1px dashed var(--tan);
+  color: var(--ink-faint);
+  font-size: 1.4rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.addMoreBtn:hover {
+  background: var(--panel-bg);
+  border-color: var(--sepia);
+}
+
+/* ── Add Spot button ── */
+.addSpotBtn {
+  position: absolute;
+  bottom: 28px;
+  right: 24px;
+  z-index: 200;
+  font-family: var(--font-body);
+  font-size: 0.72rem;
+  font-weight: 300;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  padding: 8px 16px;
+  background: var(--panel-bg);
+  color: var(--ink);
+  border: 1px solid var(--rule);
+  cursor: pointer;
+  transition: background 150ms, color 150ms, border-color 150ms;
+}
+
+.addSpotBtn:hover {
+  border-color: var(--sepia);
+}
+
+.addSpotBtnActive {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+}
+
+/* ── Drop mode banner ── */
+.dropBanner {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 14px;
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--font-body);
+  font-size: 0.72rem;
+  font-style: italic;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+
+.dropBannerClose {
+  background: transparent;
+  border: none;
+  color: var(--paper);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+  opacity: 0.7;
+  flex-shrink: 0;
+}
+
+.dropBannerClose:hover {
+  opacity: 1;
+}
+
+/* ── Mobile ── */
+@media (max-width: 580px) {
+  .inner {
+    grid-template-columns: 1fr;
+    padding: 20px 16px 28px;
+    gap: 16px;
+  }
+
+  .mediaCol {
+    padding-right: 0;
+  }
+
+  .uploadZone {
+    aspect-ratio: 16/9;
+  }
+
+  .metaCol {
+    padding-right: 0;
+  }
+}

--- a/app/src/components/map/spotCreationForm.module.css
+++ b/app/src/components/map/spotCreationForm.module.css
@@ -500,7 +500,7 @@
   position: absolute;
   bottom: 28px;
   right: 24px;
-  z-index: 200;
+  z-index: 1001;
   font-family: var(--font-body);
   font-size: 0.72rem;
   font-weight: 300;
@@ -530,6 +530,7 @@
   top: 12px;
   left: 50%;
   transform: translateX(-50%);
+  z-index: 1001;
   z-index: 200;
   display: flex;
   align-items: center;

--- a/app/supabase/migrations/0007_create_spot_fn.sql
+++ b/app/supabase/migrations/0007_create_spot_fn.sql
@@ -1,0 +1,65 @@
+-- create_spot: atomic spot + spot_networks + spot_tags insert
+--
+-- SECURITY DEFINER is required because spot_networks_insert policy checks
+-- spots.author_id via a subquery — which is blocked by spots_select RLS until
+-- the spot has at least one network attached (bootstrapping problem).
+-- Running as the function owner (superuser) bypasses that RLS cycle.
+--
+-- p_network_ids    — array of network UUIDs; at least one required
+-- p_tag_names      — array of lowercase tag strings (extracted from description #words)
+-- Returns the new spot's UUID.
+
+create or replace function public.create_spot(
+  p_title       text,
+  p_description text,
+  p_lat         double precision,
+  p_lng         double precision,
+  p_state       text,
+  p_date        date,
+  p_network_ids uuid[],
+  p_tag_names   text[] default '{}'
+) returns uuid
+language plpgsql security definer set search_path = public as $$
+declare
+  v_spot_id uuid;
+  v_tag_id  uuid;
+  v_tag     text;
+begin
+  -- Verify caller is authenticated
+  if auth.uid() is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  -- Require at least one network
+  if array_length(p_network_ids, 1) is null or array_length(p_network_ids, 1) = 0 then
+    raise exception 'At least one network is required';
+  end if;
+
+  -- Insert spot
+  insert into public.spots (author_id, title, description, lat, lng, state, date)
+  values (auth.uid(), p_title, p_description, p_lat, p_lng, p_state, p_date)
+  returning id into v_spot_id;
+
+  -- Attach networks (no RLS concern inside security definer)
+  insert into public.spot_networks (spot_id, network_id)
+  select v_spot_id, unnest(p_network_ids);
+
+  -- Upsert tags and attach spot_tags
+  foreach v_tag in array coalesce(p_tag_names, '{}') loop
+    insert into public.tags (name)
+    values (v_tag)
+    on conflict (name) do nothing;
+
+    select id into v_tag_id from public.tags where name = v_tag;
+
+    insert into public.spot_tags (spot_id, tag_id)
+    values (v_spot_id, v_tag_id)
+    on conflict do nothing;
+  end loop;
+
+  return v_spot_id;
+end;
+$$;
+
+-- Callers are authenticated users (anon cannot call this)
+grant execute on function public.create_spot(text, text, double precision, double precision, text, date, uuid[], text[]) to authenticated;

--- a/app/tests/integration/spots/create.test.ts
+++ b/app/tests/integration/spots/create.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Spot creation — Cycles SC1–SC7
+ *
+ * Verifies the create_spot RPC and related RLS rules against the live test DB.
+ * The RPC is SECURITY DEFINER to solve the spot_networks bootstrapping problem
+ * (spot_networks_insert policy checks spots.author_id via a subquery that is
+ * blocked by spots_select RLS until at least one network is attached).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import {
+  createUser,
+  signIn,
+  cleanupUsers,
+  seedNetwork,
+  seedMembership,
+  admin,
+} from '../helpers/seed'
+
+let authorId: string
+let memberId: string
+let outsiderId: string
+let authorClient: SupabaseClient
+let memberClient: SupabaseClient
+let outsiderClient: SupabaseClient
+let networkId: string
+let secondNetworkId: string
+
+beforeAll(async () => {
+  const author = await createUser('sc-author')
+  const member = await createUser('sc-member')
+  const outsider = await createUser('sc-outsider')
+
+  authorId = author.id
+  memberId = member.id
+  outsiderId = outsider.id
+
+  authorClient = await signIn(author.email, author.password)
+  memberClient = await signIn(member.email, member.password)
+  outsiderClient = await signIn(outsider.email, outsider.password)
+
+  networkId = await seedNetwork(authorId, 'SC Network A')
+  await seedMembership(memberId, networkId)
+
+  secondNetworkId = await seedNetwork(authorId, 'SC Network B')
+})
+
+afterAll(async () => {
+  await cleanupUsers([authorId, memberId, outsiderId])
+})
+
+// ---------------------------------------------------------------------------
+// SC1: create_spot RPC creates spot + spot_networks atomically
+// ---------------------------------------------------------------------------
+describe('SC1: create_spot RPC — basic creation', () => {
+  let spotId: string
+
+  afterAll(async () => {
+    if (spotId) await admin.from('spots').delete().eq('id', spotId)
+  })
+
+  it('RPC returns a UUID; row exists with correct fields', async () => {
+    const { data, error } = await authorClient.rpc('create_spot', {
+      p_title: 'SC1 Spot',
+      p_description: 'A red rock canyon. #utah #desert',
+      p_lat: 38.7436,
+      p_lng: -109.4993,
+      p_state: 'Utah',
+      p_date: '2026-04-13',
+      p_network_ids: [networkId],
+      p_tag_names: ['utah', 'desert'],
+    })
+
+    expect(error).toBeNull()
+    expect(typeof data).toBe('string')
+    spotId = data as string
+
+    const { data: row } = await admin
+      .from('spots')
+      .select('title, lat, lng, state, author_id')
+      .eq('id', spotId)
+      .single()
+
+    expect(row!.title).toBe('SC1 Spot')
+    expect(row!.state).toBe('Utah')
+    expect(row!.author_id).toBe(authorId)
+  })
+
+  it('spot_networks row exists after RPC', async () => {
+    const { data } = await admin
+      .from('spot_networks')
+      .select('network_id')
+      .eq('spot_id', spotId)
+
+    expect(data).toHaveLength(1)
+    expect(data![0].network_id).toBe(networkId)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SC2: Spot visibility after creation
+// ---------------------------------------------------------------------------
+describe('SC2: Spot visible to network member, invisible to outsider', () => {
+  let spotId: string
+
+  afterAll(async () => {
+    if (spotId) await admin.from('spots').delete().eq('id', spotId)
+  })
+
+  beforeAll(async () => {
+    const { data } = await authorClient.rpc('create_spot', {
+      p_title: 'SC2 Spot',
+      p_description: null,
+      p_lat: 45.0,
+      p_lng: -90.0,
+      p_state: null,
+      p_date: '2026-04-13',
+      p_network_ids: [networkId],
+    })
+    spotId = data as string
+  })
+
+  it('network member can SELECT the spot', async () => {
+    const { data, error } = await memberClient
+      .from('spots')
+      .select('id, title')
+      .eq('id', spotId)
+      .maybeSingle()
+
+    expect(error).toBeNull()
+    expect(data).not.toBeNull()
+    expect(data!.title).toBe('SC2 Spot')
+  })
+
+  it('outsider cannot SELECT the spot', async () => {
+    const { data, error } = await outsiderClient
+      .from('spots')
+      .select('id')
+      .eq('id', spotId)
+      .maybeSingle()
+
+    expect(error).toBeNull()
+    expect(data).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SC3: Spot across multiple networks
+// ---------------------------------------------------------------------------
+describe('SC3: Spot in two networks visible to members of either', () => {
+  let spotId: string
+  let secondMemberId: string
+  let secondMemberClient: SupabaseClient
+
+  beforeAll(async () => {
+    const sm = await createUser('sc3-member2')
+    secondMemberId = sm.id
+    secondMemberClient = await signIn(sm.email, sm.password)
+    await seedMembership(secondMemberId, secondNetworkId)
+
+    const { data } = await authorClient.rpc('create_spot', {
+      p_title: 'SC3 Spot',
+      p_description: null,
+      p_lat: 0,
+      p_lng: 0,
+      p_state: null,
+      p_date: '2026-04-13',
+      p_network_ids: [networkId, secondNetworkId],
+    })
+    spotId = data as string
+  })
+
+  afterAll(async () => {
+    if (spotId) await admin.from('spots').delete().eq('id', spotId)
+    await cleanupUsers([secondMemberId])
+  })
+
+  it('member of network A can see spot', async () => {
+    const { data } = await memberClient.from('spots').select('id').eq('id', spotId).maybeSingle()
+    expect(data).not.toBeNull()
+  })
+
+  it('member of network B can see spot', async () => {
+    const { data } = await secondMemberClient.from('spots').select('id').eq('id', spotId).maybeSingle()
+    expect(data).not.toBeNull()
+  })
+
+  it('outsider sees nothing', async () => {
+    const { data } = await outsiderClient.from('spots').select('id').eq('id', spotId).maybeSingle()
+    expect(data).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SC4: RPC requires at least one network
+// ---------------------------------------------------------------------------
+describe('SC4: create_spot requires at least one network', () => {
+  it('RPC raises exception when p_network_ids is empty', async () => {
+    const { data, error } = await authorClient.rpc('create_spot', {
+      p_title: 'SC4 No Network',
+      p_description: null,
+      p_lat: 0,
+      p_lng: 0,
+      p_state: null,
+      p_date: '2026-04-13',
+      p_network_ids: [],
+    })
+
+    expect(error).not.toBeNull()
+    expect(data).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SC5: Tags created and linked via RPC
+// ---------------------------------------------------------------------------
+describe('SC5: Tags upserted and linked by create_spot RPC', () => {
+  let spotId: string
+
+  afterAll(async () => {
+    if (spotId) await admin.from('spots').delete().eq('id', spotId)
+  })
+
+  it('spot_tags rows exist; member can read tags', async () => {
+    const { data } = await authorClient.rpc('create_spot', {
+      p_title: 'SC5 Tagged',
+      p_description: 'Notes #canyon #desert',
+      p_lat: 0,
+      p_lng: 0,
+      p_state: null,
+      p_date: '2026-04-13',
+      p_network_ids: [networkId],
+      p_tag_names: ['canyon', 'desert'],
+    })
+    spotId = data as string
+
+    const { data: tags, error } = await memberClient
+      .from('spot_tags')
+      .select('tag_id')
+      .eq('spot_id', spotId)
+
+    expect(error).toBeNull()
+    expect(tags).toHaveLength(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SC6: Media — author insert; member select; outsider blocked; type check
+// ---------------------------------------------------------------------------
+describe('SC6: Media RLS and constraints', () => {
+  let spotId: string
+
+  beforeAll(async () => {
+    const { data } = await authorClient.rpc('create_spot', {
+      p_title: 'SC6 Media Spot',
+      p_description: null,
+      p_lat: 0,
+      p_lng: 0,
+      p_state: null,
+      p_date: '2026-04-13',
+      p_network_ids: [networkId],
+    })
+    spotId = data as string
+  })
+
+  afterAll(async () => {
+    if (spotId) await admin.from('spots').delete().eq('id', spotId)
+  })
+
+  it('author inserts a media record; member can select it', async () => {
+    const fakeUrl = `https://example.com/media/${spotId}/photo.jpg`
+    const { error: insertErr } = await authorClient.from('media').insert({
+      spot_id: spotId,
+      url: fakeUrl,
+      type: 'image',
+    })
+    expect(insertErr).toBeNull()
+
+    const { data: media, error: selErr } = await memberClient
+      .from('media')
+      .select('url, type')
+      .eq('spot_id', spotId)
+    expect(selErr).toBeNull()
+    expect(media).toHaveLength(1)
+    expect(media![0].type).toBe('image')
+  })
+
+  it('outsider cannot select media', async () => {
+    const { data, error } = await outsiderClient
+      .from('media')
+      .select('url')
+      .eq('spot_id', spotId)
+    expect(error).toBeNull()
+    expect(data).toHaveLength(0)
+  })
+
+  it('media type check rejects invalid type', async () => {
+    const { error } = await admin.from('media').insert({
+      spot_id: spotId,
+      url: 'https://example.com/x.mp4',
+      type: 'video',
+    })
+    expect(error).not.toBeNull()
+    expect(error!.message).toMatch(/check/i)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SC7: Unauthenticated caller cannot create spot
+// ---------------------------------------------------------------------------
+describe('SC7: Unauthenticated RPC call is rejected', () => {
+  it('anon client gets error from create_spot', async () => {
+    const { createClient } = await import('@supabase/supabase-js')
+    const anon = createClient(
+      process.env.SUPABASE_TEST_URL!,
+      process.env.SUPABASE_TEST_ANON_KEY!,
+      { auth: { autoRefreshToken: false, persistSession: false } }
+    )
+
+    const { data, error } = await anon.rpc('create_spot', {
+      p_title: 'SC7 Anon',
+      p_description: null,
+      p_lat: 0,
+      p_lng: 0,
+      p_state: null,
+      p_date: '2026-04-13',
+      p_network_ids: [networkId],
+    })
+
+    expect(error).not.toBeNull()
+    expect(data).toBeNull()
+  })
+})

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,54 +1,60 @@
 # The Spot — Design Document
-**Chosen prototype:** Editorial Field Journal  
-**Source:** `prototypes/editorial-field-journal/index.html`
+
+**Design direction:** Editorial Field Journal — print culture meets trail guide.
+**Stack:** Next.js · React-Leaflet · Supabase · CSS Modules
 
 ---
 
-## 1. Design Direction
+## 1. Design Philosophy
 
-**Name:** Editorial Field Journal  
-**Tagline:** Print culture meets trail guide — hierarchy as spectacle, the scrapbook concept materialized.  
-**The unforgettable thing:** Every pixel feels like it was typeset for a printed field guide. Serif-only typography, ink-on-paper palette, ornamental rules, and a modal that reads like a magazine caption block.  
-**Anti-vibe-coding commitment:** No sans-serif fonts, no glassmorphism, no gradient buttons, no centered hero, no card grid. Every design choice ties back to the printed-page metaphor.
+Serif-only typography, ink-on-paper palette, and deliberate motion. Every surface feels typeset for a printed field guide.
+
+**Hard rules:**
+- No sans-serif fonts anywhere
+- No box-shadows
+- No gradient buttons or backgrounds
+- No glassmorphism
+- 3px border-radius permitted on small interactive controls (buttons, pills, tags) — softens without rounding
+- Larger surfaces (modals, panels, forms, upload zones) use sharp (0px) corners
 
 ---
 
 ## 2. Color Tokens
 
+Defined in `src/app/globals.css` as CSS custom properties.
+
 ### Light Mode (default)
 
-| Token | Hex | Semantic Role |
+| Token | Hex | Role |
 |---|---|---|
-| `--paper` | `#FAF8F3` | Primary surface (body background, overlays) |
-| `--ink` | `#2C2416` | Primary text, icons |
-| `--ink-faint` | `#9A8C78` | Secondary text, placeholders, faint labels |
-| `--sepia` | `#8B7355` | Accent text (eyebrows, captions, ornaments) |
-| `--tan` | `#C4A882` | Borders on tags, scrollbar thumb |
-| `--tan-light` | `#E8DECE` | Muted fill (image placeholder background) |
-| `--rule` | `#D4C8B4` | Divider lines, borders, separators |
+| `--paper` | `#FAF8F3` | Primary surface — body, overlays |
+| `--ink` | `#2C2416` | Primary text, icons, filled buttons |
+| `--ink-faint` | `#9A8C78` | Secondary text, placeholders, labels |
+| `--sepia` | `#8B7355` | Accent text — eyebrows, captions, autofill values |
+| `--accent` | `#7A5C38` | Interactive accent — focus states, active pins, selected |
+| `--tan` | `#C4A882` | Borders on tags/pills, dashed upload zone border |
+| `--tan-light` | `#E8DECE` | Muted fill — upload zone bg, drag hover, filter active bg |
+| `--rule` | `#D4C8B4` | Divider lines, default borders, separators |
 | `--panel-bg` | `#F4F0E8` | Side panel background (slightly darker than paper) |
-| `--modal-bg` | `#FEFCF8` | Modal background (slightly lighter/cleaner than paper) |
-| `--accent` | `#7A5C38` | Primary interactive accent (hover states, author names, active pin) |
+| `--modal-bg` | `#FEFCF8` | Modal/form background (slightly lighter/cleaner than paper) |
 
-### Dark Mode (`[data-theme="dark"]`)
+### Dark Mode (`@media (prefers-color-scheme: dark)`)
 
-| Token | Hex | Semantic Role |
+| Token | Hex | Role |
 |---|---|---|
 | `--paper` | `#1A1610` | Primary surface |
 | `--ink` | `#E8E0D0` | Primary text |
 | `--ink-faint` | `#7A7060` | Secondary text |
 | `--sepia` | `#A09070` | Accent text |
-| `--tan` | `#6A5840` | Borders |
+| `--accent` | `#C4A882` | Interactive accent (lighter in dark mode) |
+| `--tan` | `#6A5840` | Tag/pill borders |
 | `--tan-light` | `#2E2820` | Muted fill |
 | `--rule` | `#3A3028` | Dividers |
 | `--panel-bg` | `#211E18` | Side panel |
-| `--modal-bg` | `#1E1B14` | Modal |
-| `--accent` | `#C4A882` | Interactive accent (lighter in dark mode) |
+| `--modal-bg` | `#1E1B14` | Modal/form |
 
-### Theme Switching
-- Mechanism: `data-theme="light|dark"` attribute on `<html>`
-- Transition: `background 500ms ease, color 500ms ease` on `html, body`
-- Map tiles also swap on theme change (see Map component)
+**Mechanism:** `@media (prefers-color-scheme: dark)` — no JS, no `data-theme` attribute.  
+Map tiles also swap on dark mode (see Map section).
 
 ---
 
@@ -58,185 +64,193 @@
 
 | Variable | Value | Usage |
 |---|---|---|
-| `--font-serif` | `'Playfair Display', Georgia, serif` | App name, modal title, zoom controls |
-| `--font-body` | `'Source Serif 4', Georgia, serif` | All body text, UI labels, nav, metadata, comments |
+| `--font-serif` | `'Playfair Display', Georgia, serif` | Panel title, spot title, spot creation title input |
+| `--font-body` | `'Source Serif 4', Georgia, serif` | All body text, labels, inputs, buttons, metadata |
 
-**Rule:** No sans-serif fonts anywhere in the UI. Both families load from Google Fonts.
-
-```html
-<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,700;0,900;1,400;1,700&family=Source+Serif+4:ital,opsz,wght@0,8..60,300;0,8..60,400;0,8..60,600;1,8..60,300;1,8..60,400&display=swap" rel="stylesheet" />
+Loaded from Google Fonts:
+```
+Playfair Display: ital,wght 0,400; 0,600; 0,700; 1,400; 1,600
+Source Serif 4: ital,wght 0,300; 0,400; 0,600; 1,300; 1,400
 ```
 
-### Type Scale
+**Default body weight:** 300 (light). Heavier weights only for titles and strong labels.
 
-| Element | Font | Size | Weight | Style | Letter-spacing | Notes |
-|---|---|---|---|---|---|---|
-| App name | `--font-serif` | `1.75rem` | `700` | normal | `-0.01em` | Fixed overlay top-left |
-| App name subtitle | `--font-body` | `0.62rem` | `300` | italic | `0.22em` | Uppercase, color `--sepia` |
-| Panel title | `--font-serif` | `1.45rem` | `700` | normal | — | Inside side panel header |
-| Panel edition label | `--font-body` | `0.60rem` | `300` | italic | `0.25em` | Uppercase |
-| Nav links | `--font-body` | `0.82rem` | `300` | normal | `0.18em` | Uppercase |
-| Settings label | `--font-body` | `0.68rem` | `300` | italic | `0.20em` | Uppercase |
-| Theme row label | `--font-body` | `0.78rem` | `300` | normal | `0.12em` | Uppercase |
-| Search input | `--font-body` | `0.85rem` | `300` | italic | `0.06em` | |
-| Modal eyebrow (date) | `--font-body` | `0.60rem` | `300` | italic | `0.22em` | Uppercase, color `--sepia` |
-| Modal title | `--font-serif` | `1.65rem` | `700` | normal | — | Line-height `1.15` |
-| Modal byline | `--font-body` | `0.72rem` | `300` | normal | `0.08em` | Author name in `--accent` |
-| Modal description | `--font-body` | `0.82rem` | `300` | italic | — | Line-height `1.75`, wrapped in `"` quotes via CSS |
-| Modal tags | `--font-body` | `0.60rem` | `300` | normal | `0.18em` | Uppercase |
-| Modal coords | `--font-body` | `0.62rem` | `300` | normal | `0.12em` | Center-aligned |
-| Comment author | `--font-body` | `0.68rem` | `600` | normal | `0.06em` | Color `--accent` |
-| Comment text | `--font-body` | `0.78rem` | `300` | normal | — | Line-height `1.6` |
-| Footer | `--font-body` | `0.62rem` | `300` | italic | `0.06em` | |
-| Attribution | `--font-body` | `0.65rem` | — | — | — | Leaflet attribution override |
+### Type Scale (live app)
+
+| Element | Font | Size | Weight | Style | Letter-spacing |
+|---|---|---|---|---|---|
+| Panel title ("The Spot") | `--font-serif` | `1.25rem` | `600` | normal | `0.02em` |
+| Section label (e.g. "NETWORKS") | `--font-body` | `0.7rem` | `600` | normal | `0.12em` uppercase |
+| Network filter button | `--font-body` | `0.875rem` | `300` | normal | — |
+| Spot creation title input | `--font-serif` | `1.5rem` | `700` | normal | `0.01em` |
+| Spot creation description | `--font-body` | `0.9rem` | `300` | italic | — |
+| Network pill toggle | `--font-body` | `0.72rem` | `400` | normal | `0.06em` |
+| Networks row label ("Visible to") | `--font-body` | `0.7rem` | `600` | normal | `0.12em` uppercase |
+| Autofill label (Date/Author) | `--font-body` | `0.68rem` | `600` | normal | `0.1em` uppercase |
+| Autofill value | `--font-body` | `0.82rem` | `300` | italic | — |
+| Coords below upload zone | `--font-body` | `0.68rem` | `300` | italic | `0.03em` |
+| Add Spot button | `--font-body` | `0.72rem` | `300` | normal | `0.18em` uppercase |
+| Drop mode banner | `--font-body` | `0.72rem` | `300` | italic | `0.03em` |
+| Form action buttons | `--font-body` | `0.78rem` | `600` | normal | `0.14em` uppercase |
+| Discard banner | `--font-body` | `0.8rem` | `300` | italic | — |
+| Upload placeholder label | `--font-body` | `0.78rem` | `300` | italic | `0.04em` |
+| Upload hint | `--font-body` | `0.65rem` | `300` | normal | `0.06em` uppercase |
+| Field error message | `--font-body` | `0.72rem` | `300` | italic | — |
 
 ### Typography Principles
-- Small caps / uppercase labels always paired with high letter-spacing (`0.18em`+)
-- Italic used for: subtitles, captions, eyebrows, descriptions, placeholders — signals secondary/context information
-- Body weight `300` (light) is the default — not `400`. Heavier weights only for titles and author names.
-- Quoted descriptions use CSS `quotes: '\201C' '\201D'` with `::before`/`::after` — no hardcoded quote characters in markup.
+
+- Uppercase labels always paired with `letter-spacing: 0.1em+`
+- Italic signals secondary / contextual information (descriptions, captions, placeholders, autofill values)
+- Weight 300 is the default; 600+ only for titles, panel labels, and primary actions
 
 ---
 
-## 4. Layout
+## 4. Layout & Z-Index Stack
 
-### Primary Structure (z-index stack)
+### Page structure
 
-| Layer | Element | z-index | Position |
-|---|---|---|---|
-| 0 | `#map` | `0` | `fixed, inset: 0` — full viewport |
-| 1 | `#app-name` | `100` | `fixed, top: 20px, left: 64px` |
-| 2 | `#search-wrap` | `100` | `fixed, bottom: 28px, centered` |
-| 3 | `#menu-toggle` | `200` | `fixed, top: 18px, left: 18px` |
-| 4 | `#side-panel` | `150` | `fixed, top: 0, left: 0, h: 100%` |
-| 5 | `#spot-modal` | `300` | `fixed, bottom: 0, left: 0, right: 0` |
+```
+body (flex column, height: 100%)
+└── main (height: 100vh, overflow: hidden)
+    └── .layout (flex row, position: relative, height: 100vh)
+        ├── .panel (position: relative, z-index: 1000, width: 300px)
+        │     ├── .panelHeader
+        │     └── .panelSection → NetworkFilter
+        ├── .menuBtn (position: absolute, top: 12px, left: 12px, z-index: 1001)
+        │     — display: none on desktop; display: flex at ≤580px
+        └── .mapWrap (flex: 1, position: relative, z-index: 1)
+              ├── MapView (Leaflet, 100% × 100%)
+              ├── .dropBanner (position: absolute, z-index: 1001) — drop mode only
+              └── .addSpotBtn (position: absolute, bottom: 28px, right: 24px, z-index: 1001)
 
-**Note:** Side panel (`150`) sits below modal (`300`). Map click closes both panel and modal.
+SpotCreationForm (.overlay, position: fixed, bottom: 0, z-index: 300)
+```
+
+### Z-index tiers
+
+| Tier | Value | Used for |
+|---|---|---|
+| Map base | `1` | `.mapWrap` stacking context boundary — **must have z-index to contain Leaflet panes** |
+| Leaflet internals | `200–1000` | Tile/overlay/marker/popup/control panes — contained within `.mapWrap` |
+| Panel | `1000` | Side panel (desktop always visible; mobile slides in) |
+| Map overlays | `1001` | `.addSpotBtn`, `.dropBanner`, `.menuBtn` — above panel and all Leaflet elements |
+| Creation form | `300` | `position: fixed` — outside Leaflet stacking context entirely |
+
+> **Critical:** `.mapWrap` must have an explicit `z-index` (currently `1`) to establish a stacking context. Without it, Leaflet's internal panes escape their container and cover sibling UI elements regardless of their z-index.
 
 ### Key Measurements
 
 | Element | Value |
 |---|---|
 | Side panel width | `300px` (full-width on mobile) |
-| Modal max-height | `72vh` |
-| Modal image column width | `240px` (collapses to full-width on mobile) |
-| Search bar max-width | `min(480px, calc(100vw - 48px))` |
-| Hamburger button | `34px × 34px`, padding `6px` |
-| Hamburger middle bar | `70%` width (asymmetric — print-culture detail) |
+| Creation form max-height | `72vh` |
+| Form media column width | `240px` (stacks on mobile) |
+| Add Spot button position | `bottom: 28px, right: 24px` |
+| Hamburger button | `40px × 40px`, `top: 12px, left: 12px` |
+| Panel header padding | `24px 20px 12px` |
 
-### Responsive Breakpoint
+### Responsive Breakpoint: 580px
 
-Single breakpoint at `580px`:
-- `modal-inner` grid → `grid-template-columns: 1fr` (stacked)
-- Image column border-right → none; border-bottom added
-- `modal-img-frame` height → `160px` fixed
-- `#side-panel` width → `100%`
-- `#app-name` → `display: none`
+| Element | Desktop | Mobile (≤580px) |
+|---|---|---|
+| `.panel` | `position: relative; width: 300px` | `position: absolute; width: 100%; transform: translateX(-100%)` |
+| `.menuBtn` | `display: none` | `display: flex` |
+| `.inner` (creation form) | `grid-template-columns: 240px 1fr` | `grid-template-columns: 1fr` |
+| Upload zone | `aspect-ratio: 3/4` | `aspect-ratio: 16/9` |
 
 ---
 
 ## 5. Components
 
-### Map
+### Map (`MapView.tsx`)
 
-- **Library:** Leaflet `1.9.4` via `https://unpkg.com/leaflet@1.9.4/`
-- **Initial center:** `[40.5, -111.5]` (Utah/Western US), zoom `6`
-- **Light tiles:** `https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png`
-- **Dark tiles:** `https://tiles.stadiamaps.com/tiles/alidade_smooth_dark/{z}/{x}/{y}{r}.png`
-- **Zoom controls:** styled to match design — serif font, paper background, `--rule` border, no box-shadow
-- **Attribution:** Source Serif 4, `0.65rem`, color `--ink-faint`, paper background at 80% opacity, no border-radius
+- **Library:** react-leaflet + leaflet (npm)
+- **Light tiles:** OpenStreetMap (`https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png`)
+- **Dark tiles:** Stadia Alidade Smooth Dark
+- **Zoom controls:** `zoomControl={false}` — removed
+- **Attribution:** `attributionControl={false}` — removed
+- **Initial zoom:** `10` if spots exist, `3` otherwise
+- **Initial center:** centroid of visible spots, or `[51.505, -0.09]` fallback
 
-**Custom pin icon:**
+**Custom pin icon (SVG divIcon):**
+
+| State | Fill | Stroke | Center dot |
+|---|---|---|---|
+| Saved (default) | `--sepia` | none | white, 60% opacity |
+| Saved (active hover) | `--accent` | none | white, 60% opacity |
+| Provisional (drop pin) | none | `--tan`, dashed `4 3` | none |
+
 ```js
-// SVG teardrop path, sepia fill (inactive) or accent fill (active)
-// White center dot at cx=8, cy=8, r=2.8
-// iconSize: [16, 24], iconAnchor: [8, 24]
-L.divIcon({ html: svgString, className: '', iconSize: [16, 24], iconAnchor: [8, 24] })
+L.divIcon({ html: svgString, className: '', iconSize: [24, 32], iconAnchor: [12, 32], popupAnchor: [0, -34] })
 ```
 
-**Pin states:**
-- Default: `--sepia` fill, `0.88` opacity
-- Active (clicked): `--accent` fill
-- Reset to default when modal closes or map clicked
+### Side Panel (`MapPage.tsx` + `map.module.css`)
 
-### Side Panel
+- Desktop: always visible, `300px` wide, `border-right: 1px solid var(--rule)`
+- Mobile: slides in from left, `600ms cubic-bezier(0.4, 0, 0.2, 1)`
+- Contains: panel title + network filter section only (currently)
 
-**Structure:**
-```
-nav#side-panel
-  .panel-header         ← app name + edition label
-  .panel-rule           ← SVG ornamental diamond divider
-  .panel-nav            ← nav links (Profile, My Spots, Explore, Networks, Settings)
-  #settings-pane        ← hidden until Settings clicked
-  .panel-rule           ← second ornamental divider
-  .panel-footer         ← italic tagline
-```
+### Network Filter (`NetworkFilter.tsx`)
 
-**States:**
-- Closed: `transform: translateX(-100%)`
-- Open: `transform: translateX(0)`, class `open` added
-- Transition: `600ms cubic-bezier(0.4, 0, 0.2, 1)`
+- "All Networks" button always first
+- Active state: `background: var(--tan-light); border-color: var(--tan); color: var(--accent); font-weight: 600`
+- Hover: `background: var(--tan-light); border-color: var(--rule)`
+- `border-radius: 3px` — subtle rounding on small interactive controls
 
-**Ornamental rule SVG** (reused twice):
-```svg
-<svg width="14" height="10" viewBox="0 0 14 10">
-  <path d="M7 1 C5 3, 2 3, 1 5 C2 7, 5 7, 7 9 C9 7, 12 7, 13 5 C12 3, 9 3, 7 1Z"
-        fill="none" stroke="currentColor" stroke-width="0.75"/>
-</svg>
-```
+### Hamburger Button (`.menuBtn`)
 
-**Nav link hover:** color → `--accent`, background → `--tan` at 8% opacity
+- Mobile only (`≤580px`)
+- `position: absolute; top: 12px; left: 12px; z-index: 1001`
+- `40px × 40px`, `background: var(--panel-bg)`, `border: 1px solid var(--rule)`, `border-radius: 3px`
+- Sits above panel (`z-index: 1000`) so it remains tappable even when panel is open
 
-**Settings pane:** toggled via class `visible` (`display: none` → `display: block`). Contains light/dark toggle only.
+### Add Spot Button (`.addSpotBtn`)
 
-**Close triggers:** hamburger click (toggle), map click (force close)
+- `position: absolute; bottom: 28px; right: 24px` inside `.mapWrap`
+- Default: `background: var(--panel-bg); border: 1px solid var(--rule)`
+- Active (drop mode): `background: var(--ink); color: var(--paper); border-color: var(--ink)`
+- Source Serif 4, `0.72rem`, weight 300, uppercase, `letter-spacing: 0.18em`
+- No border-radius — stamp aesthetic
 
-### Search Bar
+### Drop Mode Banner (`.dropBanner`)
 
-- Position: `fixed, bottom: 28px`, horizontally centered
-- Width: `min(480px, calc(100vw - 48px))`
-- Style: underline-only (`border-bottom: 1px solid --ink-faint`), no background, no border-radius
-- Focus state: border-color → `--accent`, transition `700ms`
-- Icon: 14×14 SVG magnifier, color `--ink-faint`
-- Input: italic, weight 300, transparent background
-- Placeholder: color `--ink-faint`
+- `position: absolute; top: 12px; left: 50%; transform: translateX(-50%); z-index: 1001`
+- Ink-inverted: `background: var(--ink); color: var(--paper)`
+- Source Serif 4 italic, `0.72rem`
+- Visible only while drop mode is active; `×` button exits drop mode
+- No border-radius
 
-### Spot Modal
+### Spot Creation Form (`SpotCreationForm.tsx` + `spotCreationForm.module.css`)
 
-**Trigger:** click on map pin  
-**Open state:** `transform: translateY(0)`, class `open`  
-**Closed state:** `transform: translateY(100%)`  
-**Transition:** `750ms cubic-bezier(0.4, 0, 0.2, 1)`  
-**Close triggers:** close button click, map click
+- `position: fixed; bottom: 0; left: 0; right: 0; max-height: 72vh; z-index: 300`
+- Slides up: `translateY(100%) → translateY(0)`, `750ms cubic-bezier(0.4, 0, 0.2, 1)`
+- `background: var(--modal-bg); border-top: 1px solid var(--rule)`
+- Sharp corners on the form itself; `border-radius: 3px` on pill/tag elements inside
 
-**Top ornamental bar:** centered SVG with horizontal rules flanking a leaf/diamond motif. Close `×` button positioned absolutely to right.
+**Field order (right column):**
+1. Title input — Playfair Display 700, `1.5rem`, `border-bottom` at rest, `--accent` on focus
+2. Description textarea — italic Source Serif 4, auto-grow, `border-bottom`; supports `#hashtag` inline tagging
+3. "Visible to" + network pills (inline row)
+4. Date / Author autofill block (italic sepia values, editable on click)
+5. Discard banner (dirty-cancel confirmation) — appears inline above actions
+6. Server error (if any)
+7. Save Spot (ink fill) + Cancel (ghost) buttons
 
-**Layout (desktop):** two-column grid — `240px image col | 1fr meta col`, separated by `1px --rule` border
+**Network pills:**
+- Unselected: `border: 1px solid var(--tan); color: var(--sepia); background: transparent`
+- Selected: `background: var(--ink); color: var(--paper); border-color: var(--ink)`
+- No border-radius — stamp aesthetic
 
-**Image column:**
-- `aspect-ratio: 3/4` image frame with sepia corner tick marks (CSS `::before`/`::after` borders)
-- Placeholder: centered SVG image icon + italic "No photograph" label
-- Coordinates displayed below in small monospaced-style body text
+**Upload zone (left column):**
+- `aspect-ratio: 3/4` (16/9 on mobile)
+- Corner tick marks (CSS `::before`/`::after`-style spans), dashed inner border `1px dashed var(--tan)`
+- Empty: SVG camera icon + italic placeholder text
+- Filled: thumbnail grid (3:4 images; audio as icon + filename stub)
+- Sharp corners throughout
 
-**Metadata column sections (top to bottom):**
-1. Eyebrow (date, italic uppercase)
-2. Title (Playfair Display 700, 1.65rem)
-3. Byline (author name in `--accent`)
-4. Ornamental divider (CSS flex with `::before`/`::after` lines + `✦` glyph)
-5. Description (italic, CSS quotes, line-height 1.75)
-6. Tags (uppercase bordered pills, no border-radius, `1px solid --tan`)
-7. Comments section label
-8. Comment list (author + body, `--rule` bottom border per comment)
-
-**Scrollbar styling:** 3px width, transparent track, `--tan` thumb
-
-### Theme Toggle
-
-- Element: `<input type="checkbox">` inside `.toggle-wrap`
-- Track: pill shape (`border-radius: 22px`), default color `--rule`, checked color `--accent`
-- Knob: white circle, slides via `transform: translateX(18px)` when checked
-- Transition: `400ms` on both track color and knob position
-- On change: swaps Leaflet tile layer + sets `data-theme` on `<html>`
+**Action buttons:**
+- Primary: `background: var(--ink); color: var(--paper); border: 1px solid var(--ink)` — no border-radius
+- Ghost: `background: transparent; color: var(--ink); border: 1px solid var(--rule)` — no border-radius
 
 ---
 
@@ -244,83 +258,44 @@ nav#side-panel
 
 | Element | Property | Duration | Easing | Trigger |
 |---|---|---|---|---|
-| `html, body` | `background`, `color` | `500ms` | `ease` | Theme toggle |
-| `#side-panel` | `transform` | `600ms` | `cubic-bezier(0.4, 0, 0.2, 1)` | Menu open/close |
-| `#spot-modal` | `transform` | `750ms` | `cubic-bezier(0.4, 0, 0.2, 1)` | Pin click / close |
-| `#menu-toggle` | `opacity` | `900ms` | `ease` | Hover |
-| `.panel-nav a` | `color`, `background` | `300ms` | — | Hover |
-| `#search-wrap label` | `border-color` | `700ms` | — | Focus |
-| `#close-modal` | `opacity` | `400ms` | — | Hover |
-| `.toggle-track` | `background` | `400ms` | — | Checkbox change |
-| `.toggle-track::after` | `transform` | `400ms` | — | Checkbox change |
-| `.leaflet-control-zoom a` | `background`, `color` | (default) | — | Hover |
+| `.panel` (mobile) | `transform` | `600ms` | `cubic-bezier(0.4, 0, 0.2, 1)` | Hamburger click |
+| `.overlay` (creation form) | `transform` (slideUp) | `750ms` | `cubic-bezier(0.4, 0, 0.2, 1)` | Drop pin placed |
+| Pin fill | `fill` | `200ms` | — | Active/inactive state change |
+| Add Spot button | `background, color, border-color` | `150ms` | — | Drop mode toggle |
+| Network pill | `background, color, border-color` | `150ms` | — | Toggle selection |
+| Filter button | `background, color, border-color` | `200ms` | — | Network filter click |
+| Autofill value | `border-color, color` | — | — | Focus (instant) |
 
 **Motion principles:**
-- Slow, deliberate transitions (750–900ms for primary panels) — not snappy
-- Standard cubic-bezier `(0.4, 0, 0.2, 1)` for spatial transitions (modal, panel)
-- No animations on scroll, no staggered entrance animations, no bounce physics
+- Slow, deliberate transitions (600–750ms for primary surfaces) — editorial, not snappy
+- Standard material easing `cubic-bezier(0.4, 0, 0.2, 1)` for spatial transitions (panels, forms)
+- No scroll-triggered animations, no bounce physics, no staggered entrance
 
 ---
 
-## 7. Responsive Behavior
+## 7. Border-Radius Convention
 
-| Breakpoint | Changes |
-|---|---|
-| `> 580px` | Two-column modal grid (`240px` image + `1fr` meta), side panel `300px`, app name visible |
-| `≤ 580px` | Single-column modal (image stacked above meta), image frame `160px` fixed height, side panel full-width, app name hidden |
-
----
-
-## 8. Anti-Patterns Avoided
-
-This design explicitly does not use:
-
-| Pattern | What's used instead |
-|---|---|
-| Sans-serif fonts (Inter, Roboto, etc.) | Playfair Display + Source Serif 4 exclusively |
-| Glassmorphism / frosted glass | Solid `--panel-bg` / `--modal-bg` with `--rule` borders |
-| Neomorphism | Flat inked surfaces, rule lines as separators |
-| Standard card shadow (`box-shadow: 0 4px 6px rgba(...)`) | No box-shadows anywhere |
-| Gradient buttons | No gradient on any interactive element |
-| Centered hero + CTA layout | Map-first full-viewport layout |
-| Rounded pill inputs | Underline-only search input |
-| Purple/blue gradient palette | Warm sepia/ink/paper palette |
-| Generic card grid | No card grid — modal is the content surface |
-| Fade-in-on-scroll animations | No scroll-triggered animations |
-| Navbar (logo left, links right) | Hamburger only — no persistent navbar |
-
----
-
-## 9. Implementation Notes
-
-> These notes describe the **prototype** (`prototypes/editorial-field-journal/index.html`) specifically. The production app uses React-Leaflet (npm), Next.js, and Supabase — see `docs/prd-v1.md` for the full production stack. Design tokens, typography, and component patterns in sections 2–8 apply to both.
-
-### CDN Dependencies (prototype only)
-
-| Library | Version | URL |
+| Element type | Radius | Rationale |
 |---|---|---|
-| Leaflet CSS | `1.9.4` | `https://unpkg.com/leaflet@1.9.4/dist/leaflet.css` |
-| Leaflet JS | `1.9.4` | `https://unpkg.com/leaflet@1.9.4/dist/leaflet.js` |
-| Google Fonts | — | `Playfair+Display` + `Source+Serif+4` via fonts.googleapis.com |
+| Full-surface containers (panels, forms, overlays, upload zone) | `0px` | Hard editorial corners |
+| Small interactive controls (filter buttons, hamburger, discard/action sub-buttons) | `3px` | Subtle softening without rounding |
+| Tag-style pills (network pills, future tag chips) | `0px` | Stamp/label aesthetic |
+| Primary action buttons (Save Spot, Cancel) | `0px` | Stamp aesthetic |
+| Add Spot button | `0px` | Stamp aesthetic |
+| Theme toggle track only | `22px` (pill) | Toggle affordance exception |
 
-### Map Tile Providers
+---
 
-| Mode | Provider | URL pattern |
-|---|---|---|
-| Light | OpenStreetMap | `https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png` |
-| Dark | Stadia Alidade Smooth Dark | `https://tiles.stadiamaps.com/tiles/alidade_smooth_dark/{z}/{x}/{y}{r}.png` |
+## 8. Anti-Patterns
 
-Stadia Maps requires a free API key for production use at volume.
-
-### CSS Feature Notes
-
-- `color-mix(in srgb, var(--tan) 8%, transparent)` — used for nav hover background. Requires Chrome 111+, Firefox 113+, Safari 16.2+.
-- `inset: 0` shorthand — same support level as `color-mix`.
-- SVG ornamental elements are inline — no external SVG files needed.
-
-### Known Quirks
-
-- Map click handler closes both side panel and modal simultaneously — intentional.
-- `#app-name` uses `pointer-events: none` — cannot be interacted with (display only).
-- Leaflet attribution and zoom styles are overridden with `!important` to match design tokens — fragile if Leaflet CSS load order changes.
-- Settings pane toggled via `display: none / block` — no transition on open/close (intentional: appears instantly as a sub-section reveal).
+| Avoided | Used instead |
+|---|---|
+| Sans-serif fonts | Playfair Display + Source Serif 4 only |
+| Box-shadows | `1px solid var(--rule)` borders as elevation signal |
+| Glassmorphism | Solid `--panel-bg` / `--modal-bg` surfaces |
+| Gradient buttons | Flat ink fill or ghost border only |
+| Rounded pill buttons | Sharp corners (0px) on primary actions |
+| Centered hero layout | Map-first full-viewport |
+| Persistent navbar | Hamburger-only panel on mobile |
+| Leaflet zoom/attribution UI | Both removed (`zoomControl={false}`, `attributionControl={false}`) |
+| JS-based theme switching | `@media (prefers-color-scheme: dark)` only |

--- a/docs/design.md
+++ b/docs/design.md
@@ -275,14 +275,15 @@ L.divIcon({ html: svgString, className: '', iconSize: [24, 32], iconAnchor: [12,
 
 ## 7. Border-Radius Convention
 
-| Element type | Radius | Rationale |
+**Global token:** `--radius: 3px` (defined in `globals.css` `:root`)
+
+A global CSS rule applies `border-radius: var(--radius)` to all `button`, `input`, `textarea`, and `select` elements. No per-component overrides needed for interactive controls.
+
+| Surface | Radius | How applied |
 |---|---|---|
-| Full-surface containers (panels, forms, overlays, upload zone) | `0px` | Hard editorial corners |
-| Small interactive controls (filter buttons, hamburger, discard/action sub-buttons) | `3px` | Subtle softening without rounding |
-| Tag-style pills (network pills, future tag chips) | `0px` | Stamp/label aesthetic |
-| Primary action buttons (Save Spot, Cancel) | `0px` | Stamp aesthetic |
-| Add Spot button | `0px` | Stamp aesthetic |
-| Theme toggle track only | `22px` (pill) | Toggle affordance exception |
+| Buttons, inputs, textareas, selects | `3px` | Global rule via `--radius` |
+| Full-surface containers (panels, forms, overlays, upload zone) | `0px` | Default — no rule applied to divs |
+| Theme toggle track | `22px` (pill) | Explicit override — affordance exception |
 
 ---
 


### PR DESCRIPTION
## Summary
- `create_spot` SECURITY DEFINER RPC atomically inserts spot + spot_networks + tags, solving RLS bootstrapping cycle
- `createSpotAction` server action with Nominatim reverse geocoding (best-effort state field) and #hashtag extraction
- `SpotCreationForm` client component: two-column layout, drag-drop media upload, network pill toggles, dirty-cancel banner
- `MapView` gains drop mode: crosshair cursor, provisional pin (dashed tan hollow)
- `MapPage` wires Add Spot button, drop mode banner, Esc handler, live spots after save
- SC1–SC7 integration tests all passing against live test DB

## Closes
#8

## Human QA steps
- [ ] Click **+ Add Spot** — button inverts, banner appears at top, cursor becomes crosshair
- [ ] Press Esc — drop mode exits, cursor resets, banner disappears
- [ ] Click map — provisional pin (dashed/hollow) appears, form slides up from bottom
- [ ] Submit form with no title — inline title error shown, no submission
- [ ] Submit form with no network selected — inline network error shown
- [ ] Fill title + select network + click **Save Spot** — provisional pin turns sepia, spot appears on map, form closes
- [ ] Fill form, click Cancel — discard banner appears; confirm discards and removes provisional pin
- [ ] Edge case: resize to 375px — form stacks single column, Add Spot button stays bottom-right

🤖 Generated with [Claude Code](https://claude.com/claude-code)