### PR TITLE
feat: Spot Modal UX prototype for design review

### DIFF
--- a/app/src/components/map/MapPage.tsx
+++ b/app/src/components/map/MapPage.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useEffect } from 'react'
 import dynamic from 'next/dynamic'
 import NetworkFilter from './NetworkFilter'
 import SpotCreationForm from './SpotCreationForm'
+import SpotModal, { type SpotForModal } from './SpotModal'
 import type { CreatedSpot } from '@/app/actions/spots'
 import styles from './map.module.css'
 import formStyles from './spotCreationForm.module.css'
@@ -42,6 +43,26 @@ interface MapPageProps {
   networks: Network[]
 }
 
+// ---------------------------------------------------------------------------
+// Prototype mock data — replaced by real DB fetch in issue #10
+// ---------------------------------------------------------------------------
+const MOCK_SPOT_DETAIL: Partial<SpotForModal> = {
+  description: "Found a dense patch of chanterelles just off the main trail. Soil was damp from last week's rain. Birdsong was constant — mostly thrush. Worth returning in late September. #mushrooms #chanterelles #foraging",
+  state: "Oregon",
+  date: "April 12, 2026",
+  author: "vilnis",
+  tags: ["mushrooms", "chanterelles", "foraging"],
+  media: [
+    { type: 'image', url: '/mock/chanterelle-1.jpg' },
+    { type: 'image', url: '/mock/chanterelle-2.jpg' },
+    { type: 'audio', url: '/mock/birdsong.mp3', name: 'birdsong.mp3' },
+  ],
+  comments: [
+    { id: '1', author: 'ada', body: "I was there last week too — whole area smells incredible right now.", date: "April 11, 2026" },
+    { id: '2', author: 'reed', body: "Any morels nearby? Hoping the weather holds.", date: "April 12, 2026" },
+  ],
+}
+
 export default function MapPage({ spots: initialSpots, networks }: MapPageProps) {
   const [selectedNetworkId, setSelectedNetworkId] = useState<string | null>(null)
   const [panelOpen, setPanelOpen] = useState(false)
@@ -51,6 +72,7 @@ export default function MapPage({ spots: initialSpots, networks }: MapPageProps)
   const [provisionalPin, setProvisionalPin] = useState<LatLng | null>(null)
   const [formOpen, setFormOpen] = useState(false)
   const [droppedLatLng, setDroppedLatLng] = useState<LatLng | null>(null)
+  const [selectedSpot, setSelectedSpot] = useState<Spot | null>(null)
 
   // Esc exits drop mode
   useEffect(() => {
@@ -105,6 +127,10 @@ export default function MapPage({ spots: initialSpots, networks }: MapPageProps)
           s.spot_networks.some((sn) => sn.network_id === selectedNetworkId)
         )
 
+  const modalSpot: SpotForModal | null = selectedSpot
+    ? { ...selectedSpot, ...MOCK_SPOT_DETAIL }
+    : null
+
   return (
     <div className={styles.layout}>
       {/* Fixed button on map — shown only after panel fully slides out */}
@@ -151,6 +177,7 @@ export default function MapPage({ spots: initialSpots, networks }: MapPageProps)
           dropMode={dropMode}
           provisionalPin={provisionalPin}
           onDrop={handleDrop}
+          onSpotClick={setSelectedSpot}
         />
       </div>
 
@@ -186,6 +213,14 @@ export default function MapPage({ spots: initialSpots, networks }: MapPageProps)
         networks={networks}
         onSave={handleSave}
         onCancel={handleCancel}
+      />
+
+      <SpotModal
+        spot={modalSpot}
+        isAuthor={true}
+        onClose={() => setSelectedSpot(null)}
+        onEdit={() => { /* stub — wired in issue #10 */ }}
+        onDelete={() => { /* stub — wired in issue #10 */ }}
       />
     </div>
   )

--- a/app/src/components/map/MapView.tsx
+++ b/app/src/components/map/MapView.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState, useCallback } from 'react'
-import { MapContainer, TileLayer, Marker, Popup, useMapEvents } from 'react-leaflet'
+import { MapContainer, TileLayer, Marker, useMapEvents } from 'react-leaflet'
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 
@@ -27,6 +27,7 @@ interface MapViewProps {
   dropMode: boolean
   provisionalPin: LatLng | null
   onDrop: (latlng: LatLng) => void
+  onSpotClick: (spot: Spot) => void
 }
 
 const OSM_TILE = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
@@ -86,7 +87,7 @@ function DropHandler({ dropMode, onDrop }: { dropMode: boolean; onDrop: (latlng:
   return null
 }
 
-export default function MapView({ spots, dropMode, provisionalPin, onDrop }: MapViewProps) {
+export default function MapView({ spots, dropMode, provisionalPin, onDrop, onSpotClick }: MapViewProps) {
   const [dark, setDark] = useState(false)
 
   useEffect(() => {
@@ -109,9 +110,12 @@ export default function MapView({ spots, dropMode, provisionalPin, onDrop }: Map
       />
       <DropHandler dropMode={dropMode} onDrop={handleDrop} />
       {spots.map((spot) => (
-        <Marker key={spot.id} position={[spot.lat, spot.lng]} icon={makePinIcon('saved')}>
-          <Popup>{spot.title}</Popup>
-        </Marker>
+        <Marker
+          key={spot.id}
+          position={[spot.lat, spot.lng]}
+          icon={makePinIcon('saved')}
+          eventHandlers={{ click: () => onSpotClick(spot) }}
+        />
       ))}
       {provisionalPin && (
         <Marker

--- a/app/src/components/map/SpotModal.tsx
+++ b/app/src/components/map/SpotModal.tsx
@@ -1,0 +1,292 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import styles from './spotModal.module.css'
+
+export interface SpotMedia {
+  type: 'image' | 'audio'
+  url: string
+  name?: string
+}
+
+export interface SpotComment {
+  id: string
+  author: string
+  body: string
+  date: string
+}
+
+export interface SpotForModal {
+  id: string
+  title: string
+  lat: number
+  lng: number
+  description?: string
+  state?: string
+  date?: string
+  author?: string
+  tags?: string[]
+  media?: SpotMedia[]
+  comments?: SpotComment[]
+  spot_networks: { network_id: string }[]
+}
+
+interface SpotModalProps {
+  spot: SpotForModal | null
+  isAuthor: boolean
+  onClose: () => void
+  onEdit: () => void
+  onDelete: () => void
+}
+
+function formatCoords(lat: number, lng: number) {
+  const latStr = `${Math.abs(lat).toFixed(4)}° ${lat >= 0 ? 'N' : 'S'}`
+  const lngStr = `${Math.abs(lng).toFixed(4)}° ${lng >= 0 ? 'E' : 'W'}`
+  return `${latStr}, ${lngStr}`
+}
+
+export default function SpotModal({ spot, isAuthor, onClose, onEdit, onDelete }: SpotModalProps) {
+  const [exiting, setExiting] = useState(false)
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null)
+  const [commentText, setCommentText] = useState('')
+  const commentRef = useRef<HTMLTextAreaElement>(null)
+
+  // Reset state when a new spot opens
+  useEffect(() => {
+    if (spot) {
+      setExiting(false)
+      setLightboxIndex(null)
+      setCommentText('')
+    }
+  }, [spot?.id])
+
+  function handleClose() {
+    setExiting(true)
+    setTimeout(onClose, 750)
+  }
+
+  // Escape key closes
+  useEffect(() => {
+    if (!spot) return
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        if (lightboxIndex !== null) {
+          setLightboxIndex(null)
+        } else {
+          handleClose()
+        }
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [spot, lightboxIndex])
+
+  // Auto-grow comment textarea
+  function growComment() {
+    const el = commentRef.current
+    if (!el) return
+    el.style.height = 'auto'
+    el.style.height = el.scrollHeight + 'px'
+  }
+
+  if (!spot) return null
+
+  const images = (spot.media ?? []).filter((m) => m.type === 'image')
+  const audioFiles = (spot.media ?? []).filter((m) => m.type === 'audio')
+  const comments = spot.comments ?? []
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className={`${styles.backdrop} ${exiting ? styles.backdropExiting : ''}`}
+        onClick={handleClose}
+        aria-hidden="true"
+      />
+
+      {/* Modal sheet */}
+      <div
+        className={`${styles.sheet} ${exiting ? styles.sheetExiting : ''}`}
+        role="dialog"
+        aria-modal="true"
+        aria-label={spot.title}
+      >
+        {/* Close button */}
+        <button
+          className={styles.closeBtn}
+          onClick={handleClose}
+          aria-label="Close"
+          type="button"
+        >
+          ×
+        </button>
+
+        <div className={styles.inner}>
+          {/* ── Title (full width) ── */}
+          <h2 className={styles.title}>{spot.title}</h2>
+
+          {/* ── Main two-column body ── */}
+          <div className={styles.body}>
+            {/* Left: media */}
+            <div className={styles.mediaCol}>
+              {images.length > 0 ? (
+                <div className={styles.galleryStrip}>
+                  {images.map((img, i) => (
+                    <button
+                      key={i}
+                      type="button"
+                      className={styles.thumbBtn}
+                      onClick={() => setLightboxIndex(i)}
+                      aria-label={`View photo ${i + 1}`}
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={img.url}
+                        alt={`Photo ${i + 1}`}
+                        className={styles.thumbImg}
+                        onError={(e) => {
+                          (e.target as HTMLImageElement).style.display = 'none'
+                        }}
+                      />
+                      <div className={styles.thumbPlaceholder} aria-hidden="true" />
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <div className={styles.noMedia}>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1">
+                    <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/>
+                    <circle cx="12" cy="13" r="4"/>
+                  </svg>
+                  <span>No photographs</span>
+                </div>
+              )}
+
+              {audioFiles.map((audio, i) => (
+                <div key={i} className={styles.audioItem}>
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                    <path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/>
+                  </svg>
+                  <span className={styles.audioName}>{audio.name ?? 'audio'}</span>
+                  {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+                  <audio controls src={audio.url} className={styles.audioPlayer} />
+                </div>
+              ))}
+
+              <p className={styles.coords}>{formatCoords(spot.lat, spot.lng)}</p>
+            </div>
+
+            {/* Right: metadata */}
+            <div className={styles.metaCol}>
+              {spot.description && (
+                <p className={styles.description}>{spot.description}</p>
+              )}
+
+              {spot.tags && spot.tags.length > 0 && (
+                <div className={styles.tags}>
+                  {spot.tags.map((tag) => (
+                    <span key={tag} className={styles.tag}>#{tag}</span>
+                  ))}
+                </div>
+              )}
+
+              <div className={styles.autofill}>
+                {spot.date && <AutofillRow label="Date" value={spot.date} />}
+                {spot.author && <AutofillRow label="Author" value={spot.author} />}
+                {spot.state && <AutofillRow label="State" value={spot.state} />}
+              </div>
+
+              {isAuthor && (
+                <div className={styles.authorControls}>
+                  <button type="button" className={styles.btnEdit} onClick={onEdit}>
+                    Edit
+                  </button>
+                  <button type="button" className={styles.btnDelete} onClick={onDelete}>
+                    Delete
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* ── Comments (full width) ── */}
+          <div className={styles.commentsSection}>
+            <p className={styles.commentsLabel}>Comments</p>
+            <div className={styles.commentsList}>
+              {comments.length === 0 ? (
+                <p className={styles.noComments}>No comments yet.</p>
+              ) : (
+                comments.map((c) => (
+                  <div key={c.id} className={styles.comment}>
+                    <div className={styles.commentMeta}>
+                      <span className={styles.commentAuthor}>{c.author}</span>
+                      <span className={styles.commentDate}>{c.date}</span>
+                    </div>
+                    <p className={styles.commentBody}>{c.body}</p>
+                  </div>
+                ))
+              )}
+            </div>
+
+            <div className={styles.compose}>
+              <textarea
+                ref={commentRef}
+                className={styles.composeInput}
+                placeholder="Add a comment…"
+                rows={2}
+                value={commentText}
+                onInput={growComment}
+                onChange={(e) => setCommentText(e.target.value)}
+                aria-label="Write a comment"
+              />
+              <button
+                type="button"
+                className={styles.btnPost}
+                disabled={!commentText.trim()}
+              >
+                Post
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Lightbox */}
+      {lightboxIndex !== null && images[lightboxIndex] && (
+        <div
+          className={styles.lightbox}
+          onClick={() => setLightboxIndex(null)}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Photo"
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={images[lightboxIndex].url}
+            alt={`Photo ${lightboxIndex + 1}`}
+            className={styles.lightboxImg}
+            onClick={(e) => e.stopPropagation()}
+          />
+          <button
+            type="button"
+            className={styles.lightboxClose}
+            onClick={() => setLightboxIndex(null)}
+            aria-label="Close photo"
+          >
+            ×
+          </button>
+        </div>
+      )}
+    </>
+  )
+}
+
+function AutofillRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className={styles.autofillItem}>
+      <span className={styles.autofillLabel}>{label}</span>
+      <span className={styles.autofillValue}>{value}</span>
+    </div>
+  )
+}

--- a/app/src/components/map/spotModal.module.css
+++ b/app/src/components/map/spotModal.module.css
@@ -1,0 +1,533 @@
+/* ── Backdrop ── */
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(44, 36, 22, 0.35); /* --ink at 35% */
+  z-index: 7999;
+  animation: fadeIn 400ms ease both;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes fadeOut {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}
+
+.backdropExiting {
+  animation: fadeOut 750ms ease both;
+}
+
+/* ── Modal sheet ── */
+.sheet {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  max-height: 85vh;
+  z-index: 8000;
+  background: var(--modal-bg);
+  border-top: 1px solid var(--rule);
+  overflow-y: auto;
+  animation: slideUp 750ms cubic-bezier(0.4, 0, 0.2, 1) both;
+}
+
+@keyframes slideUp {
+  from { transform: translateY(100%); }
+  to   { transform: translateY(0); }
+}
+
+@keyframes slideDown {
+  from { transform: translateY(0); }
+  to   { transform: translateY(100%); }
+}
+
+.sheetExiting {
+  animation: slideDown 750ms cubic-bezier(0.4, 0, 0.2, 1) both;
+}
+
+/* ── Close button ── */
+.closeBtn {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  z-index: 10;
+  width: 28px;
+  height: 28px;
+  background: transparent;
+  border: 1px solid var(--rule);
+  color: var(--ink-faint);
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.closeBtn:hover {
+  border-color: var(--sepia);
+  color: var(--ink);
+}
+
+/* ── Inner padding ── */
+.inner {
+  padding: 28px 24px 36px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+/* ── Title ── */
+.title {
+  font-family: var(--font-serif);
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--ink);
+  letter-spacing: 0.01em;
+  line-height: 1.2;
+  padding-right: 40px; /* clear close btn */
+}
+
+/* ── Two-column body ── */
+.body {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 0;
+}
+
+/* ── Left: media column ── */
+.mediaCol {
+  padding-right: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  border-right: 1px solid var(--rule);
+}
+
+/* Gallery strip — horizontal scroll */
+.galleryStrip {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--rule) transparent;
+}
+
+.galleryStrip::-webkit-scrollbar {
+  height: 4px;
+}
+
+.galleryStrip::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.galleryStrip::-webkit-scrollbar-thumb {
+  background: var(--rule);
+}
+
+.thumbBtn {
+  flex-shrink: 0;
+  width: 80px;
+  aspect-ratio: 3/4;
+  padding: 0;
+  border: 1px solid var(--rule);
+  background: var(--tan-light);
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  transition: border-color 150ms;
+}
+
+.thumbBtn:hover {
+  border-color: var(--sepia);
+}
+
+.thumbImg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.thumbPlaceholder {
+  position: absolute;
+  inset: 0;
+  background: var(--tan-light);
+}
+
+.noMedia {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 24px 0;
+  color: var(--ink-faint);
+  font-family: var(--font-body);
+  font-size: 0.78rem;
+  font-style: italic;
+  letter-spacing: 0.04em;
+  background: var(--panel-bg);
+  border: 1px dashed var(--tan);
+}
+
+.audioItem {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  background: var(--panel-bg);
+  border: 1px solid var(--rule);
+  color: var(--ink-faint);
+}
+
+.audioName {
+  font-family: var(--font-body);
+  font-size: 0.72rem;
+  font-style: italic;
+  color: var(--sepia);
+  word-break: break-all;
+}
+
+.audioPlayer {
+  width: 100%;
+  height: 28px;
+  accent-color: var(--accent);
+}
+
+.coords {
+  font-family: var(--font-body);
+  font-size: 0.68rem;
+  color: var(--ink-faint);
+  font-style: italic;
+  letter-spacing: 0.03em;
+  margin-top: auto;
+}
+
+/* ── Right: meta column ── */
+.metaCol {
+  padding-left: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-right: 40px; /* clear close btn */
+}
+
+.description {
+  font-family: var(--font-body);
+  font-size: 0.9rem;
+  font-style: italic;
+  font-weight: 300;
+  color: var(--ink);
+  line-height: 1.7;
+  white-space: pre-wrap;
+}
+
+/* ── Tags ── */
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.tag {
+  font-family: var(--font-body);
+  font-size: 0.72rem;
+  font-weight: 400;
+  letter-spacing: 0.06em;
+  padding: 3px 10px;
+  border: 1px solid var(--tan);
+  color: var(--sepia);
+  background: transparent;
+  border-radius: var(--radius);
+}
+
+/* ── Autofill rows ── */
+.autofill {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.autofillItem {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+}
+
+.autofillLabel {
+  font-family: var(--font-body);
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ink-faint);
+  width: 56px;
+  flex-shrink: 0;
+}
+
+.autofillValue {
+  font-family: var(--font-body);
+  font-size: 0.82rem;
+  font-style: italic;
+  color: var(--sepia);
+}
+
+/* ── Author controls ── */
+.authorControls {
+  display: flex;
+  gap: 8px;
+  padding-top: 4px;
+}
+
+.btnEdit {
+  font-family: var(--font-body);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 5px 14px;
+  background: transparent;
+  color: var(--ink);
+  border: 1px solid var(--rule);
+  cursor: pointer;
+  transition: border-color 150ms;
+}
+
+.btnEdit:hover {
+  border-color: var(--sepia);
+}
+
+.btnDelete {
+  font-family: var(--font-body);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 5px 14px;
+  background: transparent;
+  color: #9B3A2A;
+  border: 1px solid #9B3A2A;
+  cursor: pointer;
+  transition: background 150ms, color 150ms;
+  opacity: 0.8;
+}
+
+.btnDelete:hover {
+  opacity: 1;
+}
+
+/* ── Comments section ── */
+.commentsSection {
+  border-top: 1px solid var(--rule);
+  padding-top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.commentsLabel {
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink-faint);
+}
+
+.commentsList {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.comment {
+  padding: 12px 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+.comment:first-child {
+  padding-top: 0;
+}
+
+.commentMeta {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 4px;
+}
+
+.commentAuthor {
+  font-family: var(--font-body);
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--sepia);
+  letter-spacing: 0.02em;
+}
+
+.commentDate {
+  font-family: var(--font-body);
+  font-size: 0.68rem;
+  font-style: italic;
+  color: var(--ink-faint);
+}
+
+.commentBody {
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  font-weight: 300;
+  color: var(--ink);
+  line-height: 1.6;
+}
+
+.noComments {
+  font-family: var(--font-body);
+  font-size: 0.82rem;
+  font-style: italic;
+  color: var(--ink-faint);
+  padding: 8px 0;
+}
+
+/* ── Compose area ── */
+.compose {
+  display: flex;
+  gap: 10px;
+  align-items: flex-end;
+  padding-top: 4px;
+}
+
+.composeInput {
+  flex: 1;
+  font-family: var(--font-body);
+  font-size: 0.88rem;
+  font-style: italic;
+  font-weight: 300;
+  color: var(--ink);
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--rule);
+  outline: none;
+  resize: none;
+  padding: 4px 0 6px;
+  line-height: 1.6;
+  overflow: hidden;
+  min-height: 38px;
+}
+
+.composeInput::placeholder {
+  color: var(--ink-faint);
+}
+
+.composeInput:focus {
+  border-bottom-color: var(--accent);
+}
+
+.btnPost {
+  font-family: var(--font-body);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  padding: 6px 16px;
+  background: var(--ink);
+  color: var(--paper);
+  border: 1px solid var(--ink);
+  cursor: pointer;
+  transition: opacity 150ms;
+  flex-shrink: 0;
+  align-self: flex-end;
+  margin-bottom: 6px;
+}
+
+.btnPost:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+/* ── Lightbox ── */
+.lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 9000;
+  background: rgba(44, 36, 22, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.lightboxImg {
+  max-width: 90vw;
+  max-height: 90vh;
+  object-fit: contain;
+  cursor: default;
+  display: block;
+}
+
+.lightboxClose {
+  position: absolute;
+  top: 16px;
+  right: 20px;
+  width: 36px;
+  height: 36px;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.lightboxClose:hover {
+  border-color: rgba(255, 255, 255, 0.7);
+  color: white;
+}
+
+/* ── Mobile ── */
+@media (max-width: 580px) {
+  .sheet {
+    max-height: 90vh;
+  }
+
+  .inner {
+    padding: 52px 16px 32px;
+    gap: 16px;
+  }
+
+  .title {
+    font-size: 1.4rem;
+    padding-right: 36px;
+  }
+
+  .body {
+    grid-template-columns: 1fr;
+  }
+
+  .mediaCol {
+    padding-right: 0;
+    border-right: none;
+    border-bottom: 1px solid var(--rule);
+    padding-bottom: 16px;
+  }
+
+  .galleryStrip {
+    /* horizontal scroll still works on mobile */
+  }
+
+  .metaCol {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `SpotModal` component — slide-up sheet with backdrop, Escape/outside-tap/button close
- Media gallery (horizontal scroll strip), audio player, comment thread (read + post compose)
- Author edit/delete controls (isAuthor prop)
- Mobile single-column layout at ≤580px
- Wire map pins to open modal via `onSpotClick` prop on `MapView`
- Mock spot detail data in `MapPage` for design review (replaced by real DB fetch in #10)

## Closes
#9

## Human QA steps
- [x] Drop a pin, save a spot, click its pin → modal slides up with mock chanterelle content
- [x] Verify entry animation: 750ms smooth slide-up
- [x] Verify all fields render: title, description, tags (rounded), date/author/state autofill rows
- [x] Click a gallery thumbnail → lightbox opens; click backdrop or × → closes
- [x] Audio player renders for birdsong.mp3 entry
- [x] Two mock comments visible; compose textarea + Post button present (Post disabled when empty)
- [x] Edit and Delete author controls visible
- [x] Click backdrop or × button → modal slides down
- [x] Press Escape → modal closes
- [x] Resize to 375px mobile → single column, gallery switches to horizontal scroll strip

🤖 Generated with [Claude Code](https://claude.com/claude-code)