### PR TITLE
feat: Spot Modal full implementation — real data, comments, edit, delete

### DIFF
--- a/app/src/app/actions/spots.ts
+++ b/app/src/app/actions/spots.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { createSupabaseServerClient } from '@/lib/supabase/server'
+import type { SpotForModal, SpotMedia, SpotComment } from '@/components/map/SpotModal'
 
 export interface CreatedSpot {
   id: string
@@ -13,6 +14,14 @@ export interface CreatedSpot {
 export type SpotActionResult =
   | { spot: CreatedSpot; error?: never }
   | { error: string; spot?: never }
+
+export type SpotDetailActionResult =
+  | { spot: SpotForModal; isAuthor: boolean; error?: never }
+  | { error: string; spot?: never }
+
+export type CommentActionResult =
+  | { comment: SpotComment; error?: never }
+  | { error: string; comment?: never }
 
 // ---------------------------------------------------------------------------
 // Reverse-geocode lat/lng → US state name via Nominatim (best-effort).
@@ -41,6 +50,29 @@ function extractTags(text: string | null | undefined): string[] {
   if (!text) return []
   const matches = text.match(/#([a-z0-9][a-z0-9-]*)/gi) ?? []
   return [...new Set(matches.map((t) => t.slice(1).toLowerCase()))]
+}
+
+// ---------------------------------------------------------------------------
+// Parse storage path from a URL or return as-is if already a path.
+// Handles both old format (full publicUrl) and new format (path only).
+// ---------------------------------------------------------------------------
+function parseStoragePath(urlOrPath: string): string {
+  const marker = '/storage/v1/object/public/media/'
+  const idx = urlOrPath.indexOf(marker)
+  if (idx !== -1) return urlOrPath.slice(idx + marker.length)
+  // Also handle signed URL format
+  const signedMarker = '/storage/v1/object/sign/media/'
+  const signedIdx = urlOrPath.indexOf(signedMarker)
+  if (signedIdx !== -1) return urlOrPath.slice(signedIdx + signedMarker.length).split('?')[0]
+  return urlOrPath
+}
+
+function formatDate(isoDate: string): string {
+  return new Date(isoDate + 'T00:00:00').toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  })
 }
 
 // ---------------------------------------------------------------------------
@@ -94,4 +126,200 @@ export async function createSpotAction(formData: FormData): Promise<SpotActionRe
       spot_networks: networkIds.map((network_id) => ({ network_id })),
     },
   }
+}
+
+// ---------------------------------------------------------------------------
+// getSpotDetailAction — fetch full spot detail for the modal.
+// ---------------------------------------------------------------------------
+export async function getSpotDetailAction(spotId: string): Promise<SpotDetailActionResult> {
+  const supabase = await createSupabaseServerClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  // Spot + author
+  const { data: spot, error: spotErr } = await supabase
+    .from('spots')
+    .select('id, title, description, lat, lng, state, date, author_id, profiles!author_id(username)')
+    .eq('id', spotId)
+    .single()
+
+  if (spotErr || !spot) return { error: spotErr?.message ?? 'Spot not found.' }
+
+  // Tags
+  const { data: spotTagRows } = await supabase
+    .from('spot_tags')
+    .select('tags!inner(name)')
+    .eq('spot_id', spotId)
+
+  const tags = (spotTagRows ?? []).map(
+    (row) => (row.tags as unknown as { name: string }).name
+  )
+
+  // Media — generate signed URLs
+  const { data: mediaRows } = await supabase
+    .from('media')
+    .select('id, url, type, name')
+    .eq('spot_id', spotId)
+    .order('created_at')
+
+  const media: SpotMedia[] = []
+  for (const m of mediaRows ?? []) {
+    const path = parseStoragePath(m.url)
+    const { data: signed } = await supabase.storage.from('media').createSignedUrl(path, 3600)
+    media.push({
+      id: m.id,
+      type: m.type as 'image' | 'audio',
+      url: signed?.signedUrl ?? m.url,
+      name: m.name ?? undefined,
+    })
+  }
+
+  // Comments + authors
+  const { data: commentRows } = await supabase
+    .from('comments')
+    .select('id, body, created_at, profiles!author_id(username)')
+    .eq('spot_id', spotId)
+    .order('created_at')
+
+  const comments: SpotComment[] = (commentRows ?? []).map((c) => ({
+    id: c.id,
+    author: (c.profiles as unknown as { username: string } | null)?.username ?? 'Unknown',
+    body: c.body,
+    date: formatDate(c.created_at.split('T')[0]),
+  }))
+
+  // Networks (for edit form pre-selection)
+  const { data: spotNetworks } = await supabase
+    .from('spot_networks')
+    .select('network_id')
+    .eq('spot_id', spotId)
+
+  const author = (spot.profiles as unknown as { username: string } | null)?.username
+
+  return {
+    spot: {
+      id: spot.id,
+      title: spot.title,
+      description: spot.description ?? undefined,
+      lat: spot.lat,
+      lng: spot.lng,
+      state: spot.state ?? undefined,
+      date: spot.date ? formatDate(spot.date) : undefined,
+      author: author ?? undefined,
+      tags,
+      media,
+      comments,
+      spot_networks: (spotNetworks ?? []),
+    },
+    isAuthor: !!user && user.id === spot.author_id,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// postCommentAction — insert a comment and return it with author username.
+// ---------------------------------------------------------------------------
+export async function postCommentAction(spotId: string, body: string): Promise<CommentActionResult> {
+  const supabase = await createSupabaseServerClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return { error: 'Not authenticated.' }
+
+  const trimmed = body.trim()
+  if (!trimmed) return { error: 'Comment cannot be empty.' }
+
+  const { data: comment, error } = await supabase
+    .from('comments')
+    .insert({ spot_id: spotId, author_id: user.id, body: trimmed })
+    .select('id, body, created_at, profiles!author_id(username)')
+    .single()
+
+  if (error || !comment) return { error: error?.message ?? 'Failed to post comment.' }
+
+  return {
+    comment: {
+      id: comment.id,
+      author: (comment.profiles as unknown as { username: string } | null)?.username ?? 'Unknown',
+      body: comment.body,
+      date: formatDate(comment.created_at.split('T')[0]),
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// updateSpotAction — update spot fields via update_spot RPC.
+// ---------------------------------------------------------------------------
+export async function updateSpotAction(
+  spotId: string,
+  formData: FormData
+): Promise<{ error?: string }> {
+  const supabase = await createSupabaseServerClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return { error: 'Not authenticated.' }
+
+  const title = (formData.get('title') as string | null)?.trim()
+  if (!title) return { error: 'Title is required.' }
+
+  const description = (formData.get('description') as string | null)?.trim() || null
+  const date = (formData.get('date') as string | null) || new Date().toISOString().split('T')[0]
+  const networkIds = formData.getAll('networks') as string[]
+  if (networkIds.length === 0) return { error: 'At least one network is required.' }
+
+  const tagNames = extractTags(description)
+
+  const { error: rpcError } = await supabase.rpc('update_spot', {
+    p_spot_id: spotId,
+    p_title: title,
+    p_description: description,
+    p_date: date,
+    p_network_ids: networkIds,
+    p_tag_names: tagNames,
+  })
+
+  return rpcError ? { error: rpcError.message } : {}
+}
+
+// ---------------------------------------------------------------------------
+// deleteSpotAction — delete spot; cascades to all child rows via FK.
+// RLS enforces author check on the DB side.
+// ---------------------------------------------------------------------------
+export async function deleteSpotAction(spotId: string): Promise<{ error?: string }> {
+  const supabase = await createSupabaseServerClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return { error: 'Not authenticated.' }
+
+  const { error } = await supabase.from('spots').delete().eq('id', spotId)
+  return error ? { error: error.message } : {}
+}
+
+// ---------------------------------------------------------------------------
+// removeMediaAction — delete one media item from storage and DB.
+// storagePath: the path stored in media.url (may be full URL or path).
+// ---------------------------------------------------------------------------
+export async function removeMediaAction(
+  mediaId: string,
+  storagePath: string
+): Promise<{ error?: string }> {
+  const supabase = await createSupabaseServerClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return { error: 'Not authenticated.' }
+
+  const path = parseStoragePath(storagePath)
+  // Best-effort storage delete (don't fail if file missing)
+  await supabase.storage.from('media').remove([path])
+
+  const { error } = await supabase.from('media').delete().eq('id', mediaId)
+  return error ? { error: error.message } : {}
 }

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -4,14 +4,15 @@ import MapPage from '@/components/map/MapPage'
 export default async function Home() {
   const supabase = await createSupabaseServerClient()
 
-  const [{ data: spots }, { data: networks }] = await Promise.all([
+  const [{ data: spots }, { data: networks }, { data: { user } }] = await Promise.all([
     supabase.from('spots').select('id, title, lat, lng, spot_networks(network_id)'),
     supabase.from('networks').select('id, name').order('name'),
+    supabase.auth.getUser(),
   ])
 
   return (
     <main style={{ height: '100vh', overflow: 'hidden' }}>
-      <MapPage spots={spots ?? []} networks={networks ?? []} />
+      <MapPage spots={spots ?? []} networks={networks ?? []} userId={user?.id ?? null} />
     </main>
   )
 }

--- a/app/src/components/map/MapPage.tsx
+++ b/app/src/components/map/MapPage.tsx
@@ -5,7 +5,13 @@ import dynamic from 'next/dynamic'
 import NetworkFilter from './NetworkFilter'
 import SpotCreationForm from './SpotCreationForm'
 import SpotModal, { type SpotForModal } from './SpotModal'
-import type { CreatedSpot } from '@/app/actions/spots'
+import SpotEditForm from './SpotEditForm'
+import {
+  getSpotDetailAction,
+  postCommentAction,
+  deleteSpotAction,
+  type CreatedSpot,
+} from '@/app/actions/spots'
 import styles from './map.module.css'
 import formStyles from './spotCreationForm.module.css'
 
@@ -41,29 +47,10 @@ interface LatLng {
 interface MapPageProps {
   spots: Spot[]
   networks: Network[]
+  userId: string | null
 }
 
-// ---------------------------------------------------------------------------
-// Prototype mock data — replaced by real DB fetch in issue #10
-// ---------------------------------------------------------------------------
-const MOCK_SPOT_DETAIL: Partial<SpotForModal> = {
-  description: "Found a dense patch of chanterelles just off the main trail. Soil was damp from last week's rain. Birdsong was constant — mostly thrush. Worth returning in late September. #mushrooms #chanterelles #foraging",
-  state: "Oregon",
-  date: "April 12, 2026",
-  author: "vilnis",
-  tags: ["mushrooms", "chanterelles", "foraging"],
-  media: [
-    { type: 'image', url: '/mock/chanterelle-1.jpg' },
-    { type: 'image', url: '/mock/chanterelle-2.jpg' },
-    { type: 'audio', url: '/mock/birdsong.mp3', name: 'birdsong.mp3' },
-  ],
-  comments: [
-    { id: '1', author: 'ada', body: "I was there last week too — whole area smells incredible right now.", date: "April 11, 2026" },
-    { id: '2', author: 'reed', body: "Any morels nearby? Hoping the weather holds.", date: "April 12, 2026" },
-  ],
-}
-
-export default function MapPage({ spots: initialSpots, networks }: MapPageProps) {
+export default function MapPage({ spots: initialSpots, networks, userId: _userId }: MapPageProps) {
   const [selectedNetworkId, setSelectedNetworkId] = useState<string | null>(null)
   const [panelOpen, setPanelOpen] = useState(false)
   const [panelFullyClosed, setPanelFullyClosed] = useState(true)
@@ -72,7 +59,12 @@ export default function MapPage({ spots: initialSpots, networks }: MapPageProps)
   const [provisionalPin, setProvisionalPin] = useState<LatLng | null>(null)
   const [formOpen, setFormOpen] = useState(false)
   const [droppedLatLng, setDroppedLatLng] = useState<LatLng | null>(null)
+
+  // Spot modal state
   const [selectedSpot, setSelectedSpot] = useState<Spot | null>(null)
+  const [spotDetail, setSpotDetail] = useState<SpotForModal | null>(null)
+  const [isAuthor, setIsAuthor] = useState(false)
+  const [editingSpot, setEditingSpot] = useState<SpotForModal | null>(null)
 
   // Esc exits drop mode
   useEffect(() => {
@@ -88,7 +80,6 @@ export default function MapPage({ spots: initialSpots, networks }: MapPageProps)
   function enterDropMode() {
     setDropMode(true)
     if (panelOpen) setPanelOpen(false)
-    // panelFullyClosed will be set true via onTransitionEnd
   }
 
   function exitDropMode() {
@@ -120,16 +111,69 @@ export default function MapPage({ spots: initialSpots, networks }: MapPageProps)
     setDropMode(false)
   }
 
+  // ── Spot modal interactions ──
+
+  async function handleSpotClick(spot: Spot) {
+    setSelectedSpot(spot)
+    const result = await getSpotDetailAction(spot.id)
+    if (!('error' in result)) {
+      setSpotDetail(result.spot)
+      setIsAuthor(result.isAuthor)
+    }
+  }
+
+  function handleModalClose() {
+    setSpotDetail(null)
+    setSelectedSpot(null)
+  }
+
+  function handleEdit() {
+    setEditingSpot(spotDetail)
+    setSpotDetail(null)
+  }
+
+  async function handleEditSave() {
+    if (!editingSpot) return
+    const result = await getSpotDetailAction(editingSpot.id)
+    setEditingSpot(null)
+    if (!('error' in result)) {
+      setSpotDetail(result.spot)
+      setIsAuthor(result.isAuthor)
+    }
+  }
+
+  function handleEditCancel() {
+    const snapshot = editingSpot ?? null
+    setEditingSpot(null)
+    setSpotDetail(snapshot)
+  }
+
+  async function handleDelete() {
+    if (!spotDetail) return
+    const { error } = await deleteSpotAction(spotDetail.id)
+    if (error) return
+    setLiveSpots((prev) => prev.filter((s) => s.id !== spotDetail.id))
+    setSpotDetail(null)
+    setSelectedSpot(null)
+  }
+
+  async function handlePostComment(body: string) {
+    if (!spotDetail) return
+    const result = await postCommentAction(spotDetail.id, body)
+    if (!('error' in result)) {
+      const newComment = result.comment
+      setSpotDetail((prev) =>
+        prev ? { ...prev, comments: [...(prev.comments ?? []), newComment] } : prev
+      )
+    }
+  }
+
   const visibleSpots =
     selectedNetworkId === null
       ? liveSpots
       : liveSpots.filter((s) =>
           s.spot_networks.some((sn) => sn.network_id === selectedNetworkId)
         )
-
-  const modalSpot: SpotForModal | null = selectedSpot
-    ? { ...selectedSpot, ...MOCK_SPOT_DETAIL }
-    : null
 
   return (
     <div className={styles.layout}>
@@ -152,7 +196,6 @@ export default function MapPage({ spots: initialSpots, networks }: MapPageProps)
       >
         <div className={styles.panelHeader}>
           <span className={styles.panelTitle}>The Spot</span>
-          {/* Inline button inside panel header — visible when panel is open */}
           <button
             className={styles.menuBtn}
             onClick={() => setPanelOpen(false)}
@@ -177,11 +220,11 @@ export default function MapPage({ spots: initialSpots, networks }: MapPageProps)
           dropMode={dropMode}
           provisionalPin={provisionalPin}
           onDrop={handleDrop}
-          onSpotClick={setSelectedSpot}
+          onSpotClick={handleSpotClick}
         />
       </div>
 
-      {/* Drop mode banner — at layout level, outside mapWrap stacking context */}
+      {/* Drop mode banner */}
       {dropMode && (
         <div className={formStyles.dropBanner} role="status">
           <span>Click the map to place your spot — Esc to cancel</span>
@@ -196,7 +239,7 @@ export default function MapPage({ spots: initialSpots, networks }: MapPageProps)
         </div>
       )}
 
-      {/* Add Spot button — at layout level, outside mapWrap stacking context */}
+      {/* Add Spot button */}
       <button
         type="button"
         className={`${formStyles.addSpotBtn} ${dropMode ? formStyles.addSpotBtnActive : ''}`}
@@ -216,12 +259,22 @@ export default function MapPage({ spots: initialSpots, networks }: MapPageProps)
       />
 
       <SpotModal
-        spot={modalSpot}
-        isAuthor={true}
-        onClose={() => setSelectedSpot(null)}
-        onEdit={() => { /* stub — wired in issue #10 */ }}
-        onDelete={() => { /* stub — wired in issue #10 */ }}
+        spot={spotDetail}
+        isAuthor={isAuthor}
+        onClose={handleModalClose}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+        onPostComment={handlePostComment}
       />
+
+      {editingSpot && (
+        <SpotEditForm
+          spot={editingSpot}
+          networks={networks}
+          onSave={handleEditSave}
+          onCancel={handleEditCancel}
+        />
+      )}
     </div>
   )
 }

--- a/app/src/components/map/SpotCreationForm.tsx
+++ b/app/src/components/map/SpotCreationForm.tsx
@@ -138,10 +138,8 @@ export default function SpotCreationForm({
       const path = `${spotId}/${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`
       const { error: storErr } = await supabase.storage.from('media').upload(path, file)
       if (storErr) continue // best-effort; don't fail the save
-
-      const { data: urlData } = supabase.storage.from('media').getPublicUrl(path)
       const type = ALLOWED_IMAGE_TYPES.includes(file.type) ? 'image' : 'audio'
-      await supabase.from('media').insert({ spot_id: spotId, url: urlData.publicUrl, type })
+      await supabase.from('media').insert({ spot_id: spotId, url: path, type, name: file.name })
     }
   }
 

--- a/app/src/components/map/SpotEditForm.tsx
+++ b/app/src/components/map/SpotEditForm.tsx
@@ -1,0 +1,365 @@
+'use client'
+
+import { useRef, useState, useEffect } from 'react'
+import { updateSpotAction, removeMediaAction } from '@/app/actions/spots'
+import { createSupabaseBrowserClient } from '@/lib/supabase/browser'
+import type { SpotForModal, SpotMedia } from './SpotModal'
+import styles from './spotCreationForm.module.css'
+
+interface Network {
+  id: string
+  name: string
+}
+
+interface SpotEditFormProps {
+  spot: SpotForModal
+  networks: Network[]
+  onSave: () => void
+  onCancel: () => void
+}
+
+const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp']
+const ALLOWED_AUDIO_TYPES = ['audio/mpeg', 'audio/wav', 'audio/mp4']
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024
+const MAX_AUDIO_BYTES = 20 * 1024 * 1024
+
+// Convert display date (e.g. "April 12, 2026") to ISO YYYY-MM-DD for the input
+function displayToIso(displayDate: string | undefined): string {
+  if (!displayDate) return new Date().toISOString().split('T')[0]
+  const parsed = new Date(displayDate)
+  if (isNaN(parsed.getTime())) return new Date().toISOString().split('T')[0]
+  return parsed.toISOString().split('T')[0]
+}
+
+export default function SpotEditForm({ spot, networks, onSave, onCancel }: SpotEditFormProps) {
+  const titleRef = useRef<HTMLInputElement>(null)
+  const descRef = useRef<HTMLTextAreaElement>(null)
+  const dateRef = useRef<HTMLInputElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const [pending, setPending] = useState(false)
+  const [exiting, setExiting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [titleError, setTitleError] = useState(false)
+  const [networkError, setNetworkError] = useState(false)
+
+  const [selectedNetworks, setSelectedNetworks] = useState<Set<string>>(
+    new Set(spot.spot_networks.map((sn) => sn.network_id))
+  )
+  const [existingMedia, setExistingMedia] = useState<SpotMedia[]>(spot.media ?? [])
+  const [newFiles, setNewFiles] = useState<File[]>([])
+
+  useEffect(() => {
+    const t = setTimeout(() => titleRef.current?.focus(), 100)
+    return () => clearTimeout(t)
+  }, [])
+
+  // Auto-grow textarea
+  useEffect(() => {
+    const el = descRef.current
+    if (!el) return
+    el.style.height = 'auto'
+    el.style.height = el.scrollHeight + 'px'
+  }, [])
+
+  function growDesc() {
+    const el = descRef.current
+    if (!el) return
+    el.style.height = 'auto'
+    el.style.height = el.scrollHeight + 'px'
+  }
+
+  function toggleNetwork(id: string) {
+    setSelectedNetworks((prev) => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
+    setNetworkError(false)
+  }
+
+  function handleNewFiles(fileList: FileList | null) {
+    if (!fileList) return
+    const valid: File[] = []
+    for (const f of Array.from(fileList)) {
+      const isImage = ALLOWED_IMAGE_TYPES.includes(f.type)
+      const isAudio = ALLOWED_AUDIO_TYPES.includes(f.type)
+      if (isImage && f.size <= MAX_IMAGE_BYTES) valid.push(f)
+      else if (isAudio && f.size <= MAX_AUDIO_BYTES) valid.push(f)
+    }
+    setNewFiles((prev) => [...prev, ...valid])
+  }
+
+  async function handleRemoveExisting(media: SpotMedia) {
+    if (!media.id) {
+      setExistingMedia((prev) => prev.filter((m) => m !== media))
+      return
+    }
+    await removeMediaAction(media.id, media.url)
+    setExistingMedia((prev) => prev.filter((m) => m.id !== media.id))
+  }
+
+  async function uploadNewMedia(spotId: string) {
+    if (newFiles.length === 0) return
+    const supabase = createSupabaseBrowserClient()
+    for (const file of newFiles) {
+      const ext = file.name.split('.').pop() ?? 'bin'
+      const path = `${spotId}/${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`
+      const { error: storErr } = await supabase.storage.from('media').upload(path, file)
+      if (storErr) continue
+      const type = ALLOWED_IMAGE_TYPES.includes(file.type) ? 'image' : 'audio'
+      await supabase.from('media').insert({ spot_id: spotId, url: path, type, name: file.name })
+    }
+  }
+
+  function handleClose() {
+    setExiting(true)
+    setTimeout(onCancel, 750)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+
+    const title = titleRef.current?.value.trim() ?? ''
+    if (!title) {
+      setTitleError(true)
+      titleRef.current?.focus()
+      return
+    }
+    if (selectedNetworks.size === 0) {
+      setNetworkError(true)
+      return
+    }
+
+    setPending(true)
+    setError(null)
+    setTitleError(false)
+    setNetworkError(false)
+
+    const fd = new FormData()
+    fd.set('title', title)
+    fd.set('description', descRef.current?.value ?? '')
+    fd.set('date', dateRef.current?.value ?? new Date().toISOString().split('T')[0])
+    for (const nid of selectedNetworks) fd.append('networks', nid)
+
+    const result = await updateSpotAction(spot.id, fd)
+
+    if (result.error) {
+      setError(result.error)
+      setPending(false)
+      return
+    }
+
+    await uploadNewMedia(spot.id)
+
+    setPending(false)
+    setExiting(true)
+    setTimeout(onSave, 750)
+  }
+
+  return (
+    <div
+      className={`${styles.overlay} ${exiting ? styles.overlayExiting : ''}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Edit spot"
+    >
+      <button
+        className={styles.closeBtn}
+        onClick={handleClose}
+        aria-label="Cancel edit"
+        type="button"
+        disabled={pending}
+      >
+        ×
+      </button>
+
+      <form onSubmit={handleSubmit} noValidate>
+        <div className={styles.inner}>
+          {/* ── Left: media ── */}
+          <div className={styles.mediaCol}>
+            {/* Existing media */}
+            {existingMedia.length > 0 && (
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                {existingMedia.map((m, i) => (
+                  <div key={m.id ?? i} style={{ position: 'relative', width: 64, flexShrink: 0 }}>
+                    {m.type === 'image' ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={m.url}
+                        alt={`Photo ${i + 1}`}
+                        style={{ width: 64, height: 80, objectFit: 'cover', display: 'block', border: '1px solid var(--rule)' }}
+                        onError={(e) => { (e.target as HTMLImageElement).style.display = 'none' }}
+                      />
+                    ) : (
+                      <div style={{ width: 64, height: 64, background: 'var(--panel-bg)', border: '1px solid var(--rule)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                          <path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/>
+                        </svg>
+                      </div>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveExisting(m)}
+                      aria-label="Remove media"
+                      style={{
+                        position: 'absolute', top: 2, right: 2,
+                        width: 18, height: 18, padding: 0,
+                        background: 'rgba(44,36,22,0.7)', border: 'none',
+                        color: 'white', fontSize: '0.8rem', cursor: 'pointer',
+                        display: 'flex', alignItems: 'center', justifyContent: 'center',
+                        lineHeight: 1,
+                      }}
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* New files staged */}
+            {newFiles.length > 0 && (
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                {newFiles.map((f, i) => (
+                  <div key={i} style={{ position: 'relative', width: 64, flexShrink: 0 }}>
+                    {ALLOWED_IMAGE_TYPES.includes(f.type) ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={URL.createObjectURL(f)}
+                        alt={f.name}
+                        style={{ width: 64, height: 80, objectFit: 'cover', display: 'block', border: '1px solid var(--rule)' }}
+                      />
+                    ) : (
+                      <div style={{ width: 64, height: 64, background: 'var(--panel-bg)', border: '1px solid var(--rule)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                          <path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/>
+                        </svg>
+                      </div>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => setNewFiles((prev) => prev.filter((_, j) => j !== i))}
+                      aria-label={`Remove ${f.name}`}
+                      style={{
+                        position: 'absolute', top: 2, right: 2,
+                        width: 18, height: 18, padding: 0,
+                        background: 'rgba(44,36,22,0.7)', border: 'none',
+                        color: 'white', fontSize: '0.8rem', cursor: 'pointer',
+                        display: 'flex', alignItems: 'center', justifyContent: 'center',
+                        lineHeight: 1,
+                      }}
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Add media */}
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              style={{
+                fontFamily: 'var(--font-body)',
+                fontSize: '0.72rem',
+                fontWeight: 600,
+                textTransform: 'uppercase',
+                letterSpacing: '0.1em',
+                color: 'var(--ink-faint)',
+                background: 'transparent',
+                border: '1px dashed var(--tan)',
+                padding: '8px 12px',
+                cursor: 'pointer',
+                width: '100%',
+              }}
+            >
+              + Add media
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/jpeg,image/png,image/webp,audio/mpeg,audio/wav,audio/mp4"
+              multiple
+              style={{ display: 'none' }}
+              onChange={(e) => handleNewFiles(e.target.files)}
+            />
+          </div>
+
+          {/* ── Right: metadata ── */}
+          <div className={styles.metaCol}>
+            <input
+              ref={titleRef}
+              name="title"
+              type="text"
+              className={`${styles.title} ${titleError ? styles.titleError : ''}`}
+              defaultValue={spot.title}
+              placeholder="Name this spot…"
+              aria-label="Spot title"
+              autoComplete="off"
+              onChange={() => setTitleError(false)}
+            />
+            {titleError && (
+              <p className={styles.fieldError}>A title is required to save.</p>
+            )}
+
+            <textarea
+              ref={descRef}
+              name="description"
+              className={styles.desc}
+              defaultValue={spot.description ?? ''}
+              placeholder="Field notes, observations… use #words to tag this spot."
+              aria-label="Field notes"
+              rows={3}
+              onInput={growDesc}
+            />
+
+            {/* Networks */}
+            <div className={styles.networksRow}>
+              <span className={styles.networksLabel}>Visible to</span>
+              <div className={styles.networkPills}>
+                {networks.map((n) => (
+                  <button
+                    key={n.id}
+                    type="button"
+                    className={`${styles.networkPill} ${selectedNetworks.has(n.id) ? styles.networkPillSelected : ''}`}
+                    onClick={() => toggleNetwork(n.id)}
+                  >
+                    {n.name}
+                  </button>
+                ))}
+              </div>
+            </div>
+            {networkError && (
+              <p className={styles.fieldError}>Select at least one network.</p>
+            )}
+
+            {/* Date */}
+            <div className={styles.autofill}>
+              <div className={styles.autofillItem}>
+                <span className={styles.autofillLabel}>Date</span>
+                <input
+                  ref={dateRef}
+                  name="date"
+                  type="date"
+                  className={styles.autofillValue}
+                  defaultValue={displayToIso(spot.date)}
+                  aria-label="Date"
+                />
+              </div>
+            </div>
+
+            {error && <p className={styles.serverError} role="alert">{error}</p>}
+
+            <div className={styles.actions}>
+              <button type="submit" className={styles.btnPrimary} disabled={pending}>
+                {pending ? 'Saving…' : 'Save Changes'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/app/src/components/map/SpotModal.tsx
+++ b/app/src/components/map/SpotModal.tsx
@@ -143,6 +143,7 @@ export default function SpotModal({ spot, isAuthor, onClose, onEdit, onDelete, o
                       onClick={() => setLightboxIndex(i)}
                       aria-label={`View photo ${i + 1}`}
                     >
+                      <div className={styles.thumbPlaceholder} aria-hidden="true" />
                       {/* eslint-disable-next-line @next/next/no-img-element */}
                       <img
                         src={img.url}
@@ -152,7 +153,6 @@ export default function SpotModal({ spot, isAuthor, onClose, onEdit, onDelete, o
                           (e.target as HTMLImageElement).style.display = 'none'
                         }}
                       />
-                      <div className={styles.thumbPlaceholder} aria-hidden="true" />
                     </button>
                   ))}
                 </div>

--- a/app/src/components/map/SpotModal.tsx
+++ b/app/src/components/map/SpotModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 import styles from './spotModal.module.css'
 
 export interface SpotMedia {
+  id?: string
   type: 'image' | 'audio'
   url: string
   name?: string
@@ -37,6 +38,7 @@ interface SpotModalProps {
   onClose: () => void
   onEdit: () => void
   onDelete: () => void
+  onPostComment: (body: string) => Promise<void>
 }
 
 function formatCoords(lat: number, lng: number) {
@@ -45,10 +47,11 @@ function formatCoords(lat: number, lng: number) {
   return `${latStr}, ${lngStr}`
 }
 
-export default function SpotModal({ spot, isAuthor, onClose, onEdit, onDelete }: SpotModalProps) {
+export default function SpotModal({ spot, isAuthor, onClose, onEdit, onDelete, onPostComment }: SpotModalProps) {
   const [exiting, setExiting] = useState(false)
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null)
   const [commentText, setCommentText] = useState('')
+  const [posting, setPosting] = useState(false)
   const commentRef = useRef<HTMLTextAreaElement>(null)
 
   // Reset state when a new spot opens
@@ -243,9 +246,17 @@ export default function SpotModal({ spot, isAuthor, onClose, onEdit, onDelete }:
               <button
                 type="button"
                 className={styles.btnPost}
-                disabled={!commentText.trim()}
+                disabled={!commentText.trim() || posting}
+                onClick={async () => {
+                  if (!commentText.trim()) return
+                  setPosting(true)
+                  await onPostComment(commentText)
+                  setCommentText('')
+                  if (commentRef.current) commentRef.current.style.height = 'auto'
+                  setPosting(false)
+                }}
               >
-                Post
+                {posting ? 'Posting…' : 'Post'}
               </button>
             </div>
           </div>

--- a/app/supabase/migrations/0008_spot_updates.sql
+++ b/app/supabase/migrations/0008_spot_updates.sql
@@ -1,0 +1,42 @@
+-- Add filename column to media (nullable for back-compat with existing rows)
+ALTER TABLE public.media ADD COLUMN name text;
+
+-- Atomic spot update RPC (mirrors create_spot structure)
+CREATE OR REPLACE FUNCTION public.update_spot(
+  p_spot_id     uuid,
+  p_title       text,
+  p_description text,
+  p_date        date,
+  p_network_ids uuid[],
+  p_tag_names   text[] DEFAULT '{}'
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_tag_id uuid;
+  v_tag    text;
+BEGIN
+  IF auth.uid() IS NULL THEN RAISE EXCEPTION 'Not authenticated'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM spots WHERE id = p_spot_id AND author_id = auth.uid()) THEN
+    RAISE EXCEPTION 'Not authorized';
+  END IF;
+
+  UPDATE spots SET title = p_title, description = p_description, date = p_date
+  WHERE id = p_spot_id;
+
+  -- Re-sync tags
+  DELETE FROM spot_tags WHERE spot_id = p_spot_id;
+  FOREACH v_tag IN ARRAY COALESCE(p_tag_names, '{}') LOOP
+    INSERT INTO tags (name) VALUES (v_tag) ON CONFLICT (name) DO NOTHING;
+    SELECT id INTO v_tag_id FROM tags WHERE name = v_tag;
+    INSERT INTO spot_tags (spot_id, tag_id) VALUES (p_spot_id, v_tag_id) ON CONFLICT DO NOTHING;
+  END LOOP;
+
+  -- Re-sync networks (only if caller provides at least one)
+  IF array_length(p_network_ids, 1) > 0 THEN
+    DELETE FROM spot_networks WHERE spot_id = p_spot_id;
+    INSERT INTO spot_networks (spot_id, network_id) SELECT p_spot_id, unnest(p_network_ids);
+  END IF;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.update_spot(uuid, text, text, date, uuid[], text[]) TO authenticated;


### PR DESCRIPTION
## Summary
- Real DB fetch on pin click: title, description, state, date, author, tags, media (signed URLs), comments
- Comment posting: inserts to DB, optimistic update to thread
- Edit form: pre-populated overlay, calls `update_spot` RPC (atomic tags/networks re-sync)
- Delete: removes spot from DB and map; cascades to media/tags/comments via FK
- Media fix: `SpotCreationForm.uploadMedia` now stores storage path + filename (private bucket was broken with `getPublicUrl`)
- `isAuthor` driven by real `auth.uid()` comparison; RLS enforces on DB side
- Migration `0008`: `media.name` column + `update_spot` SECURITY DEFINER RPC

## Closes
#10

## Human QA steps
- [x] Apply migration: paste `supabase/migrations/0008_spot_updates.sql` in Supabase Dashboard → SQL Editor
- [x] Click a pin → modal opens with real spot data (title, description, tags, state, date, author)
- [x] Upload a photo when creating a spot, then click that pin → image appears in gallery strip
- [x] Post a comment → thread updates immediately without reload
- [x] As author: Edit + Delete buttons visible; click Edit → pre-filled form opens; save → modal reopens with updated title
- [x] Click Delete → spot pin removed from map, modal closes
- [x] Log in as a second user → click another user's spot → no Edit/Delete controls
- [x] Edge case: non-author delete attempt via Supabase API → RLS returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)