### PR TITLE
feat: flyTo new spot pin after creation

### DIFF
--- a/app/src/components/map/MapPage.tsx
+++ b/app/src/components/map/MapPage.tsx
@@ -150,6 +150,9 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
     setFormOpen(false)
     setDroppedLatLng(null)
     setDropMode(false)
+    if (mapRef.current) {
+      mapRef.current.flyTo([spot.lat, spot.lng], 15, { animate: true, duration: 1 })
+    }
   }
 
   function handleCancel() {

--- a/app/src/components/map/MapPage.tsx
+++ b/app/src/components/map/MapPage.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
+import type L from 'leaflet'
 import dynamic from 'next/dynamic'
 import NetworkFilter from './NetworkFilter'
 import SpotCreationForm from './SpotCreationForm'
@@ -60,6 +61,9 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
   const [provisionalPin, setProvisionalPin] = useState<LatLng | null>(null)
   const [formOpen, setFormOpen] = useState(false)
   const [droppedLatLng, setDroppedLatLng] = useState<LatLng | null>(null)
+
+  // Map instance ref for programmatic flyTo
+  const mapRef = useRef<L.Map | null>(null)
 
   // Spot modal state
   const [selectedSpot, setSelectedSpot] = useState<Spot | null>(null)
@@ -160,6 +164,10 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
     setFormOpen(false)
     setDroppedLatLng(null)
     setDropMode(false)
+  }
+
+  function handleMapReady(map: L.Map) {
+    mapRef.current = map
   }
 
   // ── Spot modal interactions ──
@@ -272,6 +280,7 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
           provisionalPin={provisionalPin}
           onDrop={handleDrop}
           onSpotClick={handleSpotClick}
+          onMapReady={handleMapReady}
         />
       </div>
 

--- a/app/src/components/map/MapView.tsx
+++ b/app/src/components/map/MapView.tsx
@@ -28,6 +28,7 @@ interface MapViewProps {
   provisionalPin: LatLng | null
   onDrop: (latlng: LatLng) => void
   onSpotClick: (spot: Spot) => void
+  onMapReady?: (map: L.Map) => void
 }
 
 const OSM_TILE = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
@@ -70,7 +71,7 @@ function centroid(spots: Spot[]): [number, number] {
 }
 
 // Manages cursor and click events inside the Leaflet context
-function DropHandler({ dropMode, onDrop }: { dropMode: boolean; onDrop: (latlng: LatLng) => void }) {
+function DropHandler({ dropMode, onDrop, onMapReady }: { dropMode: boolean; onDrop: (latlng: LatLng) => void; onMapReady?: (map: L.Map) => void }) {
   const map = useMapEvents({
     click(e) {
       if (dropMode) {
@@ -80,6 +81,11 @@ function DropHandler({ dropMode, onDrop }: { dropMode: boolean; onDrop: (latlng:
   })
 
   useEffect(() => {
+    onMapReady?.(map)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
     const container = map.getContainer()
     container.style.cursor = dropMode ? 'crosshair' : ''
   }, [dropMode, map])
@@ -87,7 +93,7 @@ function DropHandler({ dropMode, onDrop }: { dropMode: boolean; onDrop: (latlng:
   return null
 }
 
-export default function MapView({ spots, dropMode, provisionalPin, onDrop, onSpotClick }: MapViewProps) {
+export default function MapView({ spots, dropMode, provisionalPin, onDrop, onSpotClick, onMapReady }: MapViewProps) {
   const [dark, setDark] = useState(false)
 
   useEffect(() => {
@@ -108,7 +114,7 @@ export default function MapView({ spots, dropMode, provisionalPin, onDrop, onSpo
         url={dark ? STADIA_DARK_TILE : OSM_TILE}
         attribution={dark ? STADIA_DARK_ATTRIBUTION : OSM_ATTRIBUTION}
       />
-      <DropHandler dropMode={dropMode} onDrop={handleDrop} />
+      <DropHandler dropMode={dropMode} onDrop={handleDrop} onMapReady={onMapReady} />
       {spots.map((spot) => (
         <Marker
           key={spot.id}


### PR DESCRIPTION
## Summary
- After a spot is saved, `mapRef.current.flyTo` animates to the new pin at zoom 15
- Modal does **not** open — pin just centers on screen
- Consistent zoom/duration with the existing search flyTo

Closes #8

## Test plan
- [x] Drop a pin, fill form, save — map flies to new pin at zoom 15
- [x] SpotModal does not open after save
- [x] New pin is visible at destination after animation
- [x] Cancel still works cleanly (no map movement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)