### PR TITLE
feat: profile page & My Spots list with map integration

### DIFF
--- a/app/src/app/actions/spots.ts
+++ b/app/src/app/actions/spots.ts
@@ -325,6 +325,75 @@ export async function removeMediaAction(
 }
 
 // ---------------------------------------------------------------------------
+// getMySpotsAction — return authenticated user's spots for the profile page.
+// Includes first signed image URL per spot + network names.
+// ---------------------------------------------------------------------------
+export interface MySpot {
+  id: string
+  title: string
+  date: string | null
+  state: string | null
+  lat: number
+  lng: number
+  thumb_url: string | null
+  network_names: string[]
+}
+
+export type MySpotListResult =
+  | { spots: MySpot[]; username: string }
+  | { error: string }
+
+export async function getMySpotsAction(): Promise<MySpotListResult> {
+  const supabase = await createSupabaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return { error: 'Not authenticated.' }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('username')
+    .eq('id', user.id)
+    .single()
+
+  const { data: rows, error } = await supabase
+    .from('spots')
+    .select('id, title, date, state, lat, lng, spot_networks(network_id, networks(name)), media(url, type)')
+    .eq('author_id', user.id)
+    .order('created_at', { ascending: false })
+
+  if (error) return { error: error.message }
+
+  const spots: MySpot[] = []
+  for (const s of rows ?? []) {
+    const networkNames = (s.spot_networks as unknown as { networks: { name: string } | null }[])
+      .map((sn) => sn.networks?.name)
+      .filter((n): n is string => !!n)
+
+    const firstImage = (s.media as { url: string; type: string }[]).find((m) => m.type === 'image')
+    let thumbUrl: string | null = null
+    if (firstImage) {
+      const path = parseStoragePath(firstImage.url)
+      const { data: signed } = await supabase.storage.from('media').createSignedUrl(path, 3600)
+      thumbUrl = signed?.signedUrl ?? null
+    }
+
+    spots.push({
+      id: s.id,
+      title: s.title,
+      date: s.date ?? null,
+      state: s.state ?? null,
+      lat: s.lat,
+      lng: s.lng,
+      thumb_url: thumbUrl,
+      network_names: networkNames,
+    })
+  }
+
+  return { spots, username: profile?.username ?? user.email ?? 'User' }
+}
+
+// ---------------------------------------------------------------------------
 // searchSpotsAction — search spots by title or tag name, RLS-enforced.
 // Empty query returns [] without a DB round-trip.
 // ---------------------------------------------------------------------------

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -1,8 +1,13 @@
 import { createSupabaseServerClient } from '@/lib/supabase/server'
 import MapPage from '@/components/map/MapPage'
 
-export default async function Home() {
+interface HomeProps {
+  searchParams: Promise<{ spot?: string }>
+}
+
+export default async function Home({ searchParams }: HomeProps) {
   const supabase = await createSupabaseServerClient()
+  const { spot } = await searchParams
 
   const [{ data: spots }, { data: networks }, { data: { user } }] = await Promise.all([
     supabase.from('spots').select('id, title, lat, lng, spot_networks(network_id)'),
@@ -12,7 +17,12 @@ export default async function Home() {
 
   return (
     <main style={{ height: '100vh', overflow: 'hidden' }}>
-      <MapPage spots={spots ?? []} networks={networks ?? []} userId={user?.id ?? null} />
+      <MapPage
+        spots={spots ?? []}
+        networks={networks ?? []}
+        userId={user?.id ?? null}
+        initialSpotId={spot ?? null}
+      />
     </main>
   )
 }

--- a/app/src/app/profile/page.tsx
+++ b/app/src/app/profile/page.tsx
@@ -1,0 +1,34 @@
+import { redirect } from 'next/navigation'
+import { createSupabaseServerClient } from '@/lib/supabase/server'
+import { getMySpotsAction } from '@/app/actions/spots'
+import ProfilePage from '@/components/profile/ProfilePage'
+
+export default async function ProfilePageRoute() {
+  const supabase = await createSupabaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) redirect('/login')
+
+  const [spotsResult, networksResult] = await Promise.all([
+    getMySpotsAction(),
+    supabase.from('networks').select('id, name').order('name'),
+  ])
+
+  if ('error' in spotsResult) {
+    return (
+      <main>
+        <p>Error loading profile: {spotsResult.error}</p>
+      </main>
+    )
+  }
+
+  return (
+    <ProfilePage
+      username={spotsResult.username}
+      spots={spotsResult.spots}
+      networks={networksResult.data ?? []}
+    />
+  )
+}

--- a/app/src/components/map/MapPage.tsx
+++ b/app/src/components/map/MapPage.tsx
@@ -144,11 +144,13 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
     window.history.replaceState(null, '', '/')
     getSpotDetailAction(initialSpotId).then((result) => {
       if ('error' in result) return
+      const { lat, lng } = result.spot
       setSpotDetail(result.spot)
       setIsAuthor(result.isAuthor)
-      pendingFlyToRef.current = { lat: result.spot.lat, lng: result.spot.lng }
+      searchedSpotRef.current = { lat, lng }
+      pendingFlyToRef.current = { lat, lng }
       if (mapRef.current) {
-        mapRef.current.flyTo([result.spot.lat, result.spot.lng], 15, { animate: true, duration: 1 })
+        mapRef.current.flyTo([lat, lng], 15, { animate: true, duration: 1 })
         pendingFlyToRef.current = null
       }
     })

--- a/app/src/components/map/MapPage.tsx
+++ b/app/src/components/map/MapPage.tsx
@@ -52,9 +52,10 @@ interface MapPageProps {
   spots: Spot[]
   networks: Network[]
   userId: string | null
+  initialSpotId: string | null
 }
 
-export default function MapPage({ spots: initialSpots, networks, userId: _userId }: MapPageProps) {
+export default function MapPage({ spots: initialSpots, networks, userId: _userId, initialSpotId }: MapPageProps) {
   const [selectedNetworkId, setSelectedNetworkId] = useState<string | null>(null)
   const [panelOpen, setPanelOpen] = useState(false)
   const [panelFullyClosed, setPanelFullyClosed] = useState(true)
@@ -75,6 +76,8 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
 
   // Tracks spot coords when modal was opened via search, for re-center on close
   const searchedSpotRef = useRef<{ lat: number; lng: number } | null>(null)
+  // Pending flyTo when map isn't ready yet (e.g. arriving via /?spot=<id>)
+  const pendingFlyToRef = useRef<{ lat: number; lng: number } | null>(null)
 
   // Esc exits drop mode
   useEffect(() => {
@@ -134,6 +137,24 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
     return () => { supabase.removeChannel(channel) }
   }, [spotDetail?.id])
 
+  // ── Handle /?spot=<id> deep link ──
+  useEffect(() => {
+    if (!initialSpotId) return
+    setSelectedNetworkId(null)
+    window.history.replaceState(null, '', '/')
+    getSpotDetailAction(initialSpotId).then((result) => {
+      if ('error' in result) return
+      setSpotDetail(result.spot)
+      setIsAuthor(result.isAuthor)
+      pendingFlyToRef.current = { lat: result.spot.lat, lng: result.spot.lng }
+      if (mapRef.current) {
+        mapRef.current.flyTo([result.spot.lat, result.spot.lng], 15, { animate: true, duration: 1 })
+        pendingFlyToRef.current = null
+      }
+    })
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialSpotId])
+
   function enterDropMode() {
     setDropMode(true)
     if (panelOpen) setPanelOpen(false)
@@ -175,6 +196,10 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
 
   function handleMapReady(map: L.Map) {
     mapRef.current = map
+    if (pendingFlyToRef.current) {
+      map.flyTo([pendingFlyToRef.current.lat, pendingFlyToRef.current.lng], 15, { animate: true, duration: 1 })
+      pendingFlyToRef.current = null
+    }
   }
 
   // ── Spot modal interactions ──

--- a/app/src/components/map/MapPage.tsx
+++ b/app/src/components/map/MapPage.tsx
@@ -8,6 +8,7 @@ import SpotCreationForm from './SpotCreationForm'
 import SpotModal, { type SpotForModal } from './SpotModal'
 import SpotEditForm from './SpotEditForm'
 import MapSearchBar from './MapSearchBar'
+import { flyToAbovePin } from './mapHelpers'
 import {
   getSpotDetailAction,
   postCommentAction,
@@ -74,8 +75,9 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
   const [isAuthor, setIsAuthor] = useState(false)
   const [editingSpot, setEditingSpot] = useState<SpotForModal | null>(null)
 
-  // Tracks spot coords when modal was opened via search, for re-center on close
-  const searchedSpotRef = useRef<{ lat: number; lng: number } | null>(null)
+  // Tracks pin coords whenever a modal is opened via offset flyTo (search,
+  // visit, or pin click) — used to pan back to true center on modal close.
+  const pinFocusRef = useRef<{ lat: number; lng: number } | null>(null)
   // Pending flyTo when map isn't ready yet (e.g. arriving via /?spot=<id>)
   const pendingFlyToRef = useRef<{ lat: number; lng: number } | null>(null)
 
@@ -147,10 +149,10 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
       const { lat, lng } = result.spot
       setSpotDetail(result.spot)
       setIsAuthor(result.isAuthor)
-      searchedSpotRef.current = { lat, lng }
+      pinFocusRef.current = { lat, lng }
       pendingFlyToRef.current = { lat, lng }
       if (mapRef.current) {
-        mapRef.current.flyTo([lat, lng], 15, { animate: true, duration: 1 })
+        flyToAbovePin(mapRef.current, lat, lng)
         pendingFlyToRef.current = null
       }
     })
@@ -199,7 +201,7 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
   function handleMapReady(map: L.Map) {
     mapRef.current = map
     if (pendingFlyToRef.current) {
-      map.flyTo([pendingFlyToRef.current.lat, pendingFlyToRef.current.lng], 15, { animate: true, duration: 1 })
+      flyToAbovePin(map, pendingFlyToRef.current.lat, pendingFlyToRef.current.lng)
       pendingFlyToRef.current = null
     }
   }
@@ -208,6 +210,8 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
 
   async function handleSpotClick(spot: Spot) {
     setSelectedSpot(spot)
+    pinFocusRef.current = { lat: spot.lat, lng: spot.lng }
+    if (mapRef.current) flyToAbovePin(mapRef.current, spot.lat, spot.lng)
     const result = await getSpotDetailAction(spot.id)
     if (!('error' in result)) {
       setSpotDetail(result.spot)
@@ -216,9 +220,9 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
   }
 
   function handleModalStartClose() {
-    if (searchedSpotRef.current) {
-      mapRef.current?.panTo([searchedSpotRef.current.lat, searchedSpotRef.current.lng], { animate: true, duration: 0.4 })
-      searchedSpotRef.current = null
+    if (pinFocusRef.current) {
+      mapRef.current?.panTo([pinFocusRef.current.lat, pinFocusRef.current.lng], { animate: true, duration: 0.4 })
+      pinFocusRef.current = null
     }
   }
 
@@ -253,17 +257,15 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
     const { error } = await deleteSpotAction(spotDetail.id)
     if (error) return
     setLiveSpots((prev) => prev.filter((s) => s.id !== spotDetail.id))
-    if (searchedSpotRef.current) {
-      mapRef.current?.panTo([searchedSpotRef.current.lat, searchedSpotRef.current.lng], { animate: true, duration: 0.4 })
-      searchedSpotRef.current = null
+    if (pinFocusRef.current) {
+      mapRef.current?.panTo([pinFocusRef.current.lat, pinFocusRef.current.lng], { animate: true, duration: 0.4 })
+      pinFocusRef.current = null
     }
     setSpotDetail(null)
     setSelectedSpot(null)
   }
 
   async function handleSearchSelect(result: SearchSpotResult) {
-    searchedSpotRef.current = { lat: result.lat, lng: result.lng }
-    mapRef.current?.flyTo([result.lat, result.lng], 15, { animate: true, duration: 1 })
     await handleSpotClick({ ...result, spot_networks: [] })
   }
 

--- a/app/src/components/map/MapPage.tsx
+++ b/app/src/components/map/MapPage.tsx
@@ -73,8 +73,6 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
   const [isAuthor, setIsAuthor] = useState(false)
   const [editingSpot, setEditingSpot] = useState<SpotForModal | null>(null)
 
-  // Map instance ref for programmatic flyTo
-  const mapRef = useRef<L.Map | null>(null)
   // Tracks spot coords when modal was opened via search, for re-center on close
   const searchedSpotRef = useRef<{ lat: number; lng: number } | null>(null)
 
@@ -236,6 +234,12 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
     setSelectedSpot(null)
   }
 
+  async function handleSearchSelect(result: SearchSpotResult) {
+    searchedSpotRef.current = { lat: result.lat, lng: result.lng }
+    mapRef.current?.flyTo([result.lat, result.lng], 15, { animate: true, duration: 1 })
+    await handleSpotClick({ ...result, spot_networks: [] })
+  }
+
   async function handlePostComment(body: string) {
     if (!spotDetail) return
     const result = await postCommentAction(spotDetail.id, body)
@@ -290,6 +294,9 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
             selected={selectedNetworkId}
             onChange={setSelectedNetworkId}
           />
+        </div>
+        <div className={styles.panelSection} style={{ marginTop: 'auto', borderTop: '1px solid var(--rule)' }}>
+          <a href="/profile" className={styles.panelNavLink}>My Profile →</a>
         </div>
       </aside>
 

--- a/app/src/components/map/map.module.css
+++ b/app/src/components/map/map.module.css
@@ -106,6 +106,22 @@
   font-weight: 600;
 }
 
+/* ── Panel nav link ── */
+.panelNavLink {
+  display: block;
+  font-family: var(--font-serif);
+  font-size: 0.85rem;
+  font-weight: 300;
+  color: var(--sepia);
+  text-decoration: none;
+  letter-spacing: 0.02em;
+  padding: 4px 0;
+}
+
+.panelNavLink:hover {
+  color: var(--accent);
+}
+
 /* ── Custom Pin ── */
 .pin {
   width: 24px;

--- a/app/src/components/map/mapHelpers.ts
+++ b/app/src/components/map/mapHelpers.ts
@@ -1,0 +1,11 @@
+import type L from 'leaflet'
+
+// flyTo a geographic point but offset the map center downward so the point
+// appears in the visible strip above an 85vh-max bottom-sheet modal.
+export function flyToAbovePin(map: L.Map, lat: number, lng: number, zoom = 15) {
+  const h = map.getContainer().clientHeight
+  const offsetY = h * 0.425
+  const targetPx = map.project([lat, lng], zoom).add([0, offsetY])
+  const center = map.unproject(targetPx, zoom)
+  map.flyTo(center, zoom, { animate: true, duration: 1 })
+}

--- a/app/src/components/map/mapHelpers.ts
+++ b/app/src/components/map/mapHelpers.ts
@@ -4,7 +4,7 @@ import type L from 'leaflet'
 // appears in the visible strip above an 85vh-max bottom-sheet modal.
 export function flyToAbovePin(map: L.Map, lat: number, lng: number, zoom = 15) {
   const h = map.getContainer().clientHeight
-  const offsetY = h * 0.425
+  const offsetY = h * 0.35
   const targetPx = map.project([lat, lng], zoom).add([0, offsetY])
   const center = map.unproject(targetPx, zoom)
   map.flyTo(center, zoom, { animate: true, duration: 1 })

--- a/app/src/components/map/spotModal.module.css
+++ b/app/src/components/map/spotModal.module.css
@@ -27,11 +27,13 @@
   bottom: 0;
   left: 0;
   right: 0;
-  max-height: 85vh;
+  height: 65vh;
   z-index: 8000;
   background: var(--modal-bg);
   border-top: 1px solid var(--rule);
-  overflow-y: auto;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
   animation: slideUp 750ms cubic-bezier(0.4, 0, 0.2, 1) both;
 }
 
@@ -80,6 +82,9 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
+  flex: 1 1 0;
+  min-height: 0;
+  overflow: hidden;
 }
 
 /* ── Title ── */
@@ -91,6 +96,7 @@
   letter-spacing: 0.01em;
   line-height: 1.2;
   padding-right: 40px; /* clear close btn */
+  flex-shrink: 0;
 }
 
 /* ── Two-column body ── */
@@ -98,6 +104,7 @@
   display: grid;
   grid-template-columns: 260px 1fr;
   gap: 0;
+  flex-shrink: 0;
 }
 
 /* ── Left: media column ── */
@@ -332,6 +339,9 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
+  flex: 1 1 0;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .commentsLabel {
@@ -341,12 +351,19 @@
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: var(--ink-faint);
+  flex-shrink: 0;
 }
 
 .commentsList {
   display: flex;
   flex-direction: column;
   gap: 0;
+  flex: 1 1 0;
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--rule) transparent;
+  padding-right: 4px;
 }
 
 .comment {
@@ -402,6 +419,7 @@
   gap: 10px;
   align-items: flex-end;
   padding-top: 4px;
+  flex-shrink: 0;
 }
 
 .composeInput {
@@ -498,7 +516,7 @@
 /* ── Mobile ── */
 @media (max-width: 580px) {
   .sheet {
-    max-height: 90vh;
+    height: 90vh;
   }
 
   .inner {

--- a/app/src/components/profile/ProfilePage.tsx
+++ b/app/src/components/profile/ProfilePage.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import SpotModal, { type SpotForModal } from '@/components/map/SpotModal'
+import SpotEditForm from '@/components/map/SpotEditForm'
+import {
+  getSpotDetailAction,
+  postCommentAction,
+  deleteSpotAction,
+  type MySpot,
+} from '@/app/actions/spots'
+import SpotCard from './SpotCard'
+import styles from './profile.module.css'
+
+interface Network {
+  id: string
+  name: string
+}
+
+interface ProfilePageProps {
+  username: string
+  spots: MySpot[]
+  networks: Network[]
+}
+
+export default function ProfilePage({ username, spots: initialSpots, networks }: ProfilePageProps) {
+  const [spots, setSpots] = useState<MySpot[]>(initialSpots)
+  const [spotDetail, setSpotDetail] = useState<SpotForModal | null>(null)
+  const [isAuthor, setIsAuthor] = useState(false)
+  const [editingSpot, setEditingSpot] = useState<SpotForModal | null>(null)
+
+  async function handleOpen(spot: MySpot) {
+    const result = await getSpotDetailAction(spot.id)
+    if (!('error' in result)) {
+      setSpotDetail(result.spot)
+      setIsAuthor(result.isAuthor)
+    }
+  }
+
+  function handleEdit(spot: MySpot) {
+    // Open detail first to get full SpotForModal, then switch to edit
+    getSpotDetailAction(spot.id).then((result) => {
+      if (!('error' in result)) {
+        setEditingSpot(result.spot)
+        setSpotDetail(null)
+      }
+    })
+  }
+
+  function handleModalEdit() {
+    setEditingSpot(spotDetail)
+    setSpotDetail(null)
+  }
+
+  async function handleDelete(spot: MySpot) {
+    const { error } = await deleteSpotAction(spot.id)
+    if (!error) {
+      setSpots((prev) => prev.filter((s) => s.id !== spot.id))
+    }
+  }
+
+  async function handleModalDelete() {
+    if (!spotDetail) return
+    const { error } = await deleteSpotAction(spotDetail.id)
+    if (!error) {
+      setSpots((prev) => prev.filter((s) => s.id !== spotDetail.id))
+      setSpotDetail(null)
+    }
+  }
+
+  async function handlePostComment(body: string) {
+    if (!spotDetail) return
+    const result = await postCommentAction(spotDetail.id, body)
+    if (!('error' in result)) {
+      setSpotDetail((prev) =>
+        prev ? { ...prev, comments: [...(prev.comments ?? []), result.comment] } : prev
+      )
+    }
+  }
+
+  async function handleEditSave() {
+    if (!editingSpot) return
+    const result = await getSpotDetailAction(editingSpot.id)
+    setEditingSpot(null)
+    if (!('error' in result)) {
+      setSpotDetail(result.spot)
+      setIsAuthor(result.isAuthor)
+    }
+  }
+
+  function handleEditCancel() {
+    const snapshot = editingSpot
+    setEditingSpot(null)
+    if (snapshot) setSpotDetail(snapshot)
+  }
+
+  return (
+    <div className={styles.page}>
+      {/* Nav */}
+      <nav className={styles.topNav}>
+        <Link href="/" className={styles.backLink}>← Map</Link>
+        <span className={styles.navDivider}>·</span>
+        <span className={styles.navTitle}>Profile</span>
+      </nav>
+
+      {/* Profile header */}
+      <header className={styles.profileHeader}>
+        <h1 className={styles.username}>{username}</h1>
+        <p className={styles.spotCount}>
+          {spots.length === 0
+            ? 'No spots yet'
+            : spots.length === 1
+            ? '1 spot'
+            : `${spots.length} spots`}
+        </p>
+      </header>
+
+      {/* My Spots list */}
+      <section className={styles.section}>
+        <p className={styles.sectionLabel}>My Spots</p>
+        {spots.length === 0 ? (
+          <p className={styles.emptyState}>You haven&apos;t pinned any spots yet.</p>
+        ) : (
+          <ul className={styles.spotsList}>
+            {spots.map((spot) => (
+              <SpotCard
+                key={spot.id}
+                spot={spot}
+                onOpen={handleOpen}
+                onEdit={handleEdit}
+                onDelete={handleDelete}
+              />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Spot modal */}
+      <SpotModal
+        spot={spotDetail}
+        isAuthor={isAuthor}
+        onClose={() => setSpotDetail(null)}
+        onEdit={handleModalEdit}
+        onDelete={handleModalDelete}
+        onPostComment={handlePostComment}
+      />
+
+      {/* Edit form */}
+      {editingSpot && (
+        <SpotEditForm
+          spot={editingSpot}
+          networks={networks}
+          onSave={handleEditSave}
+          onCancel={handleEditCancel}
+        />
+      )}
+    </div>
+  )
+}

--- a/app/src/components/profile/SpotCard.tsx
+++ b/app/src/components/profile/SpotCard.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+import { useState } from 'react'
+import type { MySpot } from '@/app/actions/spots'
+import styles from './profile.module.css'
+
+function formatDate(isoDate: string): string {
+  return new Date(isoDate + 'T00:00:00').toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+interface SpotCardProps {
+  spot: MySpot
+  onOpen: (spot: MySpot) => void
+  onEdit: (spot: MySpot) => void
+  onDelete: (spot: MySpot) => void
+}
+
+export default function SpotCard({ spot, onOpen, onEdit, onDelete }: SpotCardProps) {
+  const [controlsOpen, setControlsOpen] = useState(false)
+
+  function handleCardClick(e: React.MouseEvent) {
+    // Don't open modal if a control button was clicked
+    const target = e.target as HTMLElement
+    if (target.closest('button')) return
+    onOpen(spot)
+  }
+
+  function handleEdit(e: React.MouseEvent) {
+    e.stopPropagation()
+    onEdit(spot)
+  }
+
+  function handleDelete(e: React.MouseEvent) {
+    e.stopPropagation()
+    onDelete(spot)
+  }
+
+  function handleMore(e: React.MouseEvent) {
+    e.stopPropagation()
+    setControlsOpen((v) => !v)
+  }
+
+  const sub = [spot.date ? formatDate(spot.date) : null, spot.state]
+    .filter(Boolean)
+    .join(' · ')
+
+  return (
+    <li className={styles.spotCard} onClick={handleCardClick}>
+      {/* Thumbnail */}
+      {spot.thumb_url ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={spot.thumb_url}
+          alt=""
+          className={styles.thumb}
+          onError={(e) => {
+            // Fallback to placeholder on broken URL
+            ;(e.target as HTMLImageElement).style.display = 'none'
+          }}
+        />
+      ) : (
+        <div className={styles.thumbPlaceholder} aria-hidden="true">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1">
+            <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/>
+            <circle cx="12" cy="13" r="4"/>
+          </svg>
+        </div>
+      )}
+
+      {/* Meta */}
+      <div className={styles.meta}>
+        <p className={styles.cardTitle}>{spot.title}</p>
+        {sub && <p className={styles.cardSub}>{sub}</p>}
+        {spot.network_names.length > 0 && (
+          <div className={styles.networkPills}>
+            {spot.network_names.map((name) => (
+              <span key={name} className={styles.networkPill}>{name}</span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Controls */}
+      <div className={styles.cardControls}>
+        {/* Touch: ⋯ toggles edit/delete */}
+        <button
+          type="button"
+          className={styles.moreBtn}
+          onClick={handleMore}
+          aria-label="More options"
+          aria-expanded={controlsOpen}
+        >
+          ···
+        </button>
+        <button
+          type="button"
+          className={`${styles.editBtn}${controlsOpen ? ` ${styles.visible}` : ''}`}
+          onClick={handleEdit}
+          aria-label={`Edit ${spot.title}`}
+          title="Edit"
+        >
+          ✎
+        </button>
+        <button
+          type="button"
+          className={`${styles.deleteBtn}${controlsOpen ? ` ${styles.visible}` : ''}`}
+          onClick={handleDelete}
+          aria-label={`Delete ${spot.title}`}
+          title="Delete"
+        >
+          ✕
+        </button>
+      </div>
+    </li>
+  )
+}

--- a/app/src/components/profile/SpotCard.tsx
+++ b/app/src/components/profile/SpotCard.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useState } from 'react'
 import type { MySpot } from '@/app/actions/spots'
 import styles from './profile.module.css'
 
@@ -20,8 +19,6 @@ interface SpotCardProps {
 }
 
 export default function SpotCard({ spot, onOpen, onEdit, onDelete }: SpotCardProps) {
-  const [controlsOpen, setControlsOpen] = useState(false)
-
   function handleCardClick(e: React.MouseEvent) {
     // Don't open modal if a control button was clicked
     const target = e.target as HTMLElement
@@ -37,11 +34,6 @@ export default function SpotCard({ spot, onOpen, onEdit, onDelete }: SpotCardPro
   function handleDelete(e: React.MouseEvent) {
     e.stopPropagation()
     onDelete(spot)
-  }
-
-  function handleMore(e: React.MouseEvent) {
-    e.stopPropagation()
-    setControlsOpen((v) => !v)
   }
 
   const sub = [spot.date ? formatDate(spot.date) : null, spot.state]
@@ -86,19 +78,9 @@ export default function SpotCard({ spot, onOpen, onEdit, onDelete }: SpotCardPro
 
       {/* Controls */}
       <div className={styles.cardControls}>
-        {/* Touch: ⋯ toggles edit/delete */}
         <button
           type="button"
-          className={styles.moreBtn}
-          onClick={handleMore}
-          aria-label="More options"
-          aria-expanded={controlsOpen}
-        >
-          ···
-        </button>
-        <button
-          type="button"
-          className={`${styles.editBtn}${controlsOpen ? ` ${styles.visible}` : ''}`}
+          className={styles.editBtn}
           onClick={handleEdit}
           aria-label={`Edit ${spot.title}`}
           title="Edit"
@@ -107,7 +89,7 @@ export default function SpotCard({ spot, onOpen, onEdit, onDelete }: SpotCardPro
         </button>
         <button
           type="button"
-          className={`${styles.deleteBtn}${controlsOpen ? ` ${styles.visible}` : ''}`}
+          className={styles.deleteBtn}
           onClick={handleDelete}
           aria-label={`Delete ${spot.title}`}
           title="Delete"

--- a/app/src/components/profile/SpotCard.tsx
+++ b/app/src/components/profile/SpotCard.tsx
@@ -36,6 +36,11 @@ export default function SpotCard({ spot, onOpen, onEdit, onDelete }: SpotCardPro
     onDelete(spot)
   }
 
+  function handleVisit(e: React.MouseEvent) {
+    e.stopPropagation()
+    window.location.href = `/?spot=${spot.id}`
+  }
+
   const sub = [spot.date ? formatDate(spot.date) : null, spot.state]
     .filter(Boolean)
     .join(' · ')
@@ -78,6 +83,17 @@ export default function SpotCard({ spot, onOpen, onEdit, onDelete }: SpotCardPro
 
       {/* Controls */}
       <div className={styles.cardControls}>
+        <button
+          type="button"
+          className={styles.visitBtn}
+          onClick={handleVisit}
+          aria-label={`View ${spot.title} on map`}
+          title="View on map"
+        >
+          <svg viewBox="0 0 24 32" width="12" height="16" fill="currentColor" aria-hidden="true">
+            <path d="M12 0C6.477 0 2 4.477 2 10c0 7 10 22 10 22S22 17 22 10C22 4.477 17.523 0 12 0z"/>
+          </svg>
+        </button>
         <button
           type="button"
           className={styles.editBtn}

--- a/app/src/components/profile/profile.module.css
+++ b/app/src/components/profile/profile.module.css
@@ -196,11 +196,8 @@
   align-items: center;
 }
 
-/* Hover device: show expanded controls on card hover */
+/* Hover device: fade in on card hover */
 @media (hover: hover) {
-  .moreBtn {
-    display: none;
-  }
   .editBtn,
   .deleteBtn {
     opacity: 0;
@@ -214,22 +211,6 @@
   }
 }
 
-/* Touch device: always show ⋯; expanded controls toggled via JS */
-@media (hover: none) {
-  .moreBtn {
-    display: flex;
-  }
-  .editBtn,
-  .deleteBtn {
-    display: none;
-  }
-  .editBtn.visible,
-  .deleteBtn.visible {
-    display: flex;
-  }
-}
-
-.moreBtn,
 .editBtn,
 .deleteBtn {
   width: 28px;
@@ -256,11 +237,6 @@
 .deleteBtn:hover {
   color: #b04030;
   border-color: #b04030;
-}
-
-.moreBtn:hover {
-  color: var(--ink);
-  border-color: var(--ink-faint);
 }
 
 /* ── Responsive ── */

--- a/app/src/components/profile/profile.module.css
+++ b/app/src/components/profile/profile.module.css
@@ -1,0 +1,277 @@
+/* ── Page layout ── */
+.page {
+  min-height: 100vh;
+  background: var(--paper);
+  color: var(--ink);
+}
+
+/* ── Top nav bar ── */
+.topNav {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--rule);
+  background: var(--panel-bg);
+}
+
+.backLink {
+  font-family: var(--font-serif);
+  font-size: 0.85rem;
+  font-weight: 300;
+  color: var(--sepia);
+  text-decoration: none;
+  letter-spacing: 0.02em;
+}
+
+.backLink:hover {
+  color: var(--accent);
+}
+
+.navDivider {
+  color: var(--rule);
+  font-size: 0.85rem;
+}
+
+.navTitle {
+  font-family: var(--font-serif);
+  font-size: 0.85rem;
+  font-weight: 300;
+  color: var(--ink-faint);
+  letter-spacing: 0.02em;
+}
+
+/* ── Profile header ── */
+.profileHeader {
+  padding: 32px 24px 24px;
+  border-bottom: 1px solid var(--rule);
+  background: var(--modal-bg);
+}
+
+.username {
+  font-family: var(--font-serif);
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--ink);
+  letter-spacing: 0.01em;
+  margin: 0 0 6px;
+}
+
+.spotCount {
+  font-family: var(--font-serif);
+  font-size: 0.85rem;
+  font-weight: 300;
+  color: var(--ink-faint);
+  letter-spacing: 0.04em;
+}
+
+/* ── Section ── */
+.section {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 24px 24px 48px;
+}
+
+.sectionLabel {
+  font-family: var(--font-serif);
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink-faint);
+  margin-bottom: 0;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--rule);
+}
+
+/* ── Spots list ── */
+.spotsList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.emptyState {
+  font-family: var(--font-serif);
+  font-size: 0.9rem;
+  font-weight: 300;
+  color: var(--ink-faint);
+  padding: 24px 0;
+  font-style: italic;
+}
+
+/* ── Spot card ── */
+.spotCard {
+  display: flex;
+  gap: 14px;
+  padding: 14px 8px;
+  border-bottom: 1px solid var(--rule);
+  cursor: pointer;
+  position: relative;
+  transition: background 160ms;
+  margin: 0 -8px;
+}
+
+.spotCard:hover {
+  background: var(--tan-light);
+}
+
+/* Thumb */
+.thumb {
+  width: 80px;
+  height: 80px;
+  flex-shrink: 0;
+  object-fit: cover;
+  border: 1px solid var(--rule);
+  display: block;
+}
+
+.thumbPlaceholder {
+  width: 80px;
+  height: 80px;
+  flex-shrink: 0;
+  background: var(--tan-light);
+  border: 1px solid var(--rule);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ink-faint);
+}
+
+/* Meta column */
+.meta {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding-right: 40px; /* leave room for controls */
+}
+
+.cardTitle {
+  font-family: var(--font-serif);
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0;
+}
+
+.cardSub {
+  font-family: var(--font-serif);
+  font-size: 0.8rem;
+  font-weight: 300;
+  color: var(--ink-faint);
+}
+
+.networkPills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 2px;
+}
+
+.networkPill {
+  font-family: var(--font-serif);
+  font-size: 0.7rem;
+  font-weight: 400;
+  color: var(--sepia);
+  border: 1px solid var(--tan);
+  padding: 2px 7px;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+/* ── Card controls ── */
+/* Desktop: fade in on hover */
+.cardControls {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+/* Hover device: show expanded controls on card hover */
+@media (hover: hover) {
+  .moreBtn {
+    display: none;
+  }
+  .editBtn,
+  .deleteBtn {
+    opacity: 0;
+    transition: opacity 160ms;
+    pointer-events: none;
+  }
+  .spotCard:hover .editBtn,
+  .spotCard:hover .deleteBtn {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+/* Touch device: always show ⋯; expanded controls toggled via JS */
+@media (hover: none) {
+  .moreBtn {
+    display: flex;
+  }
+  .editBtn,
+  .deleteBtn {
+    display: none;
+  }
+  .editBtn.visible,
+  .deleteBtn.visible {
+    display: flex;
+  }
+}
+
+.moreBtn,
+.editBtn,
+.deleteBtn {
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--rule);
+  background: var(--modal-bg);
+  color: var(--ink-faint);
+  cursor: pointer;
+  font-family: var(--font-serif);
+  font-size: 0.85rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 3px;
+  transition: color 160ms, border-color 160ms;
+  flex-shrink: 0;
+}
+
+.editBtn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.deleteBtn:hover {
+  color: #b04030;
+  border-color: #b04030;
+}
+
+.moreBtn:hover {
+  color: var(--ink);
+  border-color: var(--ink-faint);
+}
+
+/* ── Responsive ── */
+@media (max-width: 480px) {
+  .profileHeader {
+    padding: 24px 16px 20px;
+  }
+  .section {
+    padding: 20px 16px 40px;
+  }
+  .topNav {
+    padding: 14px 16px;
+  }
+}

--- a/app/src/components/profile/profile.module.css
+++ b/app/src/components/profile/profile.module.css
@@ -145,7 +145,7 @@
   display: flex;
   flex-direction: column;
   gap: 5px;
-  padding-right: 40px; /* leave room for controls */
+  padding-right: 104px; /* leave room for 3 control buttons */
 }
 
 .cardTitle {
@@ -198,12 +198,14 @@
 
 /* Hover device: fade in on card hover */
 @media (hover: hover) {
+  .visitBtn,
   .editBtn,
   .deleteBtn {
     opacity: 0;
     transition: opacity 160ms;
     pointer-events: none;
   }
+  .spotCard:hover .visitBtn,
   .spotCard:hover .editBtn,
   .spotCard:hover .deleteBtn {
     opacity: 1;
@@ -211,6 +213,7 @@
   }
 }
 
+.visitBtn,
 .editBtn,
 .deleteBtn {
   width: 28px;
@@ -227,6 +230,11 @@
   border-radius: 3px;
   transition: color 160ms, border-color 160ms;
   flex-shrink: 0;
+}
+
+.visitBtn:hover {
+  color: var(--sepia);
+  border-color: var(--sepia);
 }
 
 .editBtn:hover {


### PR DESCRIPTION
## Summary
- Add Profile page with My Spots list (horizontal cards: thumb, title, date/state, network pills)
- Edit (✎) and delete (✕) buttons revealed on hover; visit pin button navigates to `/?spot=<id>`
- `/?spot=<id>` deep link opens SpotModal and flies to pin above modal on arrival
- `flyToAbovePin` helper extracts offset flyTo logic — used by search, visit, and pin click
- Rename `searchedSpotRef` → `pinFocusRef`; pan back to true center on modal close
- SpotModal capped at 65vh (Loyola reference); comments list scrolls independently; compose box stays fixed at bottom

## Closes
#13

## Human QA steps
- [x] Visit `/profile` — spot list renders with thumbnails, titles, dates, network pills
- [x] Hover a card — ✎ ✕ and pin buttons fade in
- [x] Click pin button — navigates to map, modal opens, pin is visible above modal, URL reverts to `/`
- [x] Close modal — map pans so pin is centered
- [x] Search for a spot — pin visible above modal; close — pin centered
- [x] Click a map pin — same above-modal behavior
- [x] Open Loyola spot — modal height ≈ 65vh, top section fully visible
- [x] Open a spot with many comments — comments list scrolls, title/media/description stay fixed, compose always visible at bottom
- [x] Mobile (≤580px) — modal at 90vh, same scroll behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)