### PR TITLE
feat: explore mode hides chrome for distraction-free map viewing

### DIFF
--- a/app/src/components/map/ExploreExitChip.tsx
+++ b/app/src/components/map/ExploreExitChip.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import styles from './map.module.css'
+
+interface ExploreExitChipProps {
+  onExit: () => void
+}
+
+export default function ExploreExitChip({ onExit }: ExploreExitChipProps) {
+  return (
+    <button
+      type="button"
+      className={styles.exploreExitChip}
+      onClick={onExit}
+      aria-label="Exit explore mode"
+    >
+      <kbd className={styles.exploreExitKey}>esc</kbd>
+      <span className={styles.exploreExitLabel}>exit</span>
+    </button>
+  )
+}

--- a/app/src/components/map/MapPage.tsx
+++ b/app/src/components/map/MapPage.tsx
@@ -8,6 +8,8 @@ import SpotCreationForm from './SpotCreationForm'
 import SpotModal, { type SpotForModal } from './SpotModal'
 import SpotEditForm from './SpotEditForm'
 import MapSearchBar from './MapSearchBar'
+import ExploreExitChip from './ExploreExitChip'
+import { useExploreMode } from './useExploreMode'
 import { flyToAbovePin } from './mapHelpers'
 import {
   getSpotDetailAction,
@@ -75,6 +77,19 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
   const [spotDetail, setSpotDetail] = useState<SpotForModal | null>(null)
   const [isAuthor, setIsAuthor] = useState(false)
   const [editingSpot, setEditingSpot] = useState<SpotForModal | null>(null)
+
+  // Explore mode — hides chrome for distraction-free map viewing
+  const isModalOpen = useCallback(
+    () => spotDetail !== null || editingSpot !== null || formOpen,
+    [spotDetail, editingSpot, formOpen]
+  )
+  const { exploreMode, enterExplore, exitExplore } = useExploreMode({ isModalOpen })
+
+  function handleEnterExplore() {
+    setPanelOpen(false)
+    setPanelFullyClosed(true)
+    enterExplore()
+  }
 
   // Tracks pin coords whenever a modal is opened via offset flyTo (search,
   // visit, or pin click) — used to pan back to true center on modal close.
@@ -293,7 +308,7 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
   return (
     <div className={styles.layout}>
       {/* Fixed button on map — shown only after panel fully slides out */}
-      {panelFullyClosed && (
+      {panelFullyClosed && !exploreMode && (
         <button
           className={styles.menuBtn}
           onClick={() => { setPanelOpen(true); setPanelFullyClosed(false) }}
@@ -302,6 +317,8 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
           ☰
         </button>
       )}
+
+      {exploreMode && <ExploreExitChip onExit={exitExplore} />}
 
       <aside
         className={`${styles.panel} ${panelOpen ? styles.panelOpen : ''}`}
@@ -328,6 +345,14 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
           />
         </div>
         <div className={styles.panelSection} style={{ marginTop: 'auto', borderTop: '1px solid var(--rule)' }}>
+          <button
+            type="button"
+            className={styles.panelNavLink}
+            style={{ background: 'none', border: 'none', padding: '4px 0', cursor: 'pointer', textAlign: 'left' }}
+            onClick={handleEnterExplore}
+          >
+            Explore
+          </button>
           <a href="/profile" className={styles.panelNavLink}>Profile</a>
           <a href="/settings" className={styles.panelNavLink}>Settings</a>
         </div>
@@ -342,7 +367,7 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
           onSpotClick={handleSpotClick}
           onMapReady={handleMapReady}
         />
-        <MapSearchBar onSelectSpot={handleSearchSelect} />
+        {!exploreMode && <MapSearchBar onSelectSpot={handleSearchSelect} />}
       </div>
 
       {/* Drop mode banner */}
@@ -361,15 +386,17 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
       )}
 
       {/* Add Spot button */}
-      <button
-        type="button"
-        className={`${formStyles.addSpotBtn} ${dropMode ? formStyles.addSpotBtnActive : ''}`}
-        onClick={dropMode ? exitDropMode : enterDropMode}
-        aria-label={dropMode ? 'Cancel adding spot' : 'Add a new spot'}
-        aria-pressed={dropMode}
-      >
-        + Add Spot
-      </button>
+      {!exploreMode && (
+        <button
+          type="button"
+          className={`${formStyles.addSpotBtn} ${dropMode ? formStyles.addSpotBtnActive : ''}`}
+          onClick={dropMode ? exitDropMode : enterDropMode}
+          aria-label={dropMode ? 'Cancel adding spot' : 'Add a new spot'}
+          aria-pressed={dropMode}
+        >
+          + Add Spot
+        </button>
+      )}
 
       <SpotCreationForm
         open={formOpen}

--- a/app/src/components/map/exploreEsc.ts
+++ b/app/src/components/map/exploreEsc.ts
@@ -1,0 +1,14 @@
+export interface ExploreEscContext {
+  exploreMode: boolean
+  modalOpen: boolean
+}
+
+export function shouldExitExploreOnEsc(
+  event: KeyboardEvent,
+  ctx: ExploreEscContext
+): boolean {
+  if (event.key !== 'Escape') return false
+  if (!ctx.exploreMode) return false
+  if (ctx.modalOpen) return false
+  return true
+}

--- a/app/src/components/map/map.module.css
+++ b/app/src/components/map/map.module.css
@@ -173,6 +173,51 @@
   transform: translateX(0);
 }
 
+/* ── Explore mode exit chip ── */
+.exploreExitChip {
+  position: fixed;
+  top: 12px;
+  left: 12px;
+  z-index: 9000;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: var(--panel-bg);
+  border: 1px solid var(--rule);
+  cursor: pointer;
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-size: 0.75rem;
+  font-weight: 300;
+  letter-spacing: 0.04em;
+  transition: border-color 150ms, color 150ms;
+  animation: slideInFromLeft 400ms cubic-bezier(0.4, 0, 0.2, 1) both;
+}
+
+.exploreExitChip:hover {
+  border-color: var(--sepia);
+  color: var(--accent);
+}
+
+.exploreExitKey {
+  display: inline-block;
+  padding: 1px 5px;
+  font-family: var(--font-body);
+  font-size: 0.68rem;
+  font-weight: 500;
+  background: var(--tan-light);
+  border: 1px solid var(--rule);
+  border-bottom-width: 2px;
+  border-radius: 3px;
+  color: var(--ink);
+  line-height: 1;
+}
+
+.exploreExitLabel {
+  color: var(--ink-faint);
+}
+
 /* ── Mobile ── */
 @media (max-width: 580px) {
   .panel {

--- a/app/src/components/map/useExploreMode.ts
+++ b/app/src/components/map/useExploreMode.ts
@@ -1,0 +1,34 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { shouldExitExploreOnEsc } from './exploreEsc'
+
+export interface UseExploreModeArgs {
+  isModalOpen: () => boolean
+}
+
+export interface UseExploreMode {
+  exploreMode: boolean
+  enterExplore: () => void
+  exitExplore: () => void
+}
+
+export function useExploreMode({ isModalOpen }: UseExploreModeArgs): UseExploreMode {
+  const [exploreMode, setExploreMode] = useState(false)
+
+  const enterExplore = useCallback(() => setExploreMode(true), [])
+  const exitExplore = useCallback(() => setExploreMode(false), [])
+
+  useEffect(() => {
+    if (!exploreMode) return
+    function handleKey(e: KeyboardEvent) {
+      if (shouldExitExploreOnEsc(e, { exploreMode: true, modalOpen: isModalOpen() })) {
+        setExploreMode(false)
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [exploreMode, isModalOpen])
+
+  return { exploreMode, enterExplore, exitExplore }
+}

--- a/app/tests/unit/exploreEsc.test.ts
+++ b/app/tests/unit/exploreEsc.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { shouldExitExploreOnEsc } from '../../src/components/map/exploreEsc'
+
+describe('shouldExitExploreOnEsc', () => {
+  const esc = { key: 'Escape' } as KeyboardEvent
+  const notEsc = { key: 'a' } as KeyboardEvent
+
+  it('exits when explore active, key is Escape, no modal open', () => {
+    expect(shouldExitExploreOnEsc(esc, { exploreMode: true, modalOpen: false })).toBe(true)
+  })
+
+  it('does not exit when key is not Escape', () => {
+    expect(shouldExitExploreOnEsc(notEsc, { exploreMode: true, modalOpen: false })).toBe(false)
+  })
+
+  it('does not exit when explore mode is off', () => {
+    expect(shouldExitExploreOnEsc(esc, { exploreMode: false, modalOpen: false })).toBe(false)
+  })
+
+  it('does not exit when a modal is open (modal Esc handler takes precedence)', () => {
+    expect(shouldExitExploreOnEsc(esc, { exploreMode: true, modalOpen: true })).toBe(false)
+  })
+})

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vitest/config'
+import path from 'path'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
   test: {
-    include: ['tests/integration/**/*.test.ts'],
+    include: ['tests/integration/**/*.test.ts', 'tests/unit/**/*.test.ts'],
     environment: 'node',
     setupFiles: ['./tests/integration/setup.ts'],
     testTimeout: 20000,

--- a/docs/UBIQUITOUS_LANGUAGE.md
+++ b/docs/UBIQUITOUS_LANGUAGE.md
@@ -32,6 +32,8 @@
 | **Spot Modal** | The panel that opens when a Pin is clicked, displaying a Spot's full details | Popup, drawer, detail view, card |
 | **Fly-to** | The animated map transition that moves the viewport to a Spot's location | Pan, jump, navigate, zoom-to |
 | **Drop** | The act of placing a Pin on the map to begin creating a new Spot | Place, add, create (in map context) |
+| **Drop mode** | The transient state the map enters after a Member chooses to add a Spot, during which the next map click becomes the Drop point | Add mode, placement mode |
+| **Explore mode** | A distraction-free map viewing state that hides all chrome (side panel trigger, search bar, Add Spot button), leaving only an `esc` exit chip. Pins remain clickable. Ephemeral — lost on reload. Distinct from Drop mode: Explore is for viewing, Drop is for creating | Focus mode, fullscreen mode, immersive mode |
 
 ## Spot Details
 


### PR DESCRIPTION
## Summary
- New **Explore mode**: entered from the hamburger side panel's bottom nav section. Hides the hamburger button, search bar, and + Add Spot button, leaving only a small keycap-style `esc exit` chip at top-left.
- Esc key or clicking the chip exits. If a modal (spot detail, edit, creation) is open, Esc closes the modal first (existing handlers untouched).
- Ephemeral state — not persisted to URL or reload.
- New `useExploreMode` hook encapsulates state + keydown wiring; `shouldExitExploreOnEsc` pure helper is unit-tested (4 cases).
- Added `tests/unit/` vitest include for pure-function unit tests (separate from existing integration suite).
- `docs/UBIQUITOUS_LANGUAGE.md` defines **Explore mode** (and **Drop mode** for contrast).

## Closes
#34

## Human QA steps
- [ ] Open map at `/`. Click hamburger (☰) top-left. In the bottom nav section of the panel, click **Explore**.
- [ ] Verify: side panel closes instantly, hamburger button disappears, search bar disappears, + Add Spot button disappears, a small `esc exit` chip appears top-left.
- [ ] Press **Esc**. Verify all chrome returns and the chip disappears.
- [ ] Re-enter Explore mode. Click the `esc exit` chip (not the key). Verify it exits the same way.
- [ ] Enter Explore mode. Click a pin on the map. Verify the Spot modal opens normally.
- [ ] With the Spot modal open in Explore mode, press **Esc**. Verify the modal closes but Explore mode is still active (chip still visible, chrome still hidden).
- [ ] Press **Esc** again. Verify Explore mode exits.
- [ ] Reload the page while in Explore mode. Verify the page comes back in normal mode (Explore is ephemeral).
- [ ] Edge case: open the side panel, then click Explore while the panel is mid-animation. Verify the panel snaps closed and chrome hides cleanly (no leftover panel).
- [ ] Edge case: start adding a spot (+ Add Spot → click map → form opens), then try entering Explore mode — should not be reachable (side panel is closed; creation form is modal). Cancel the form, then verify Explore is reachable again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)