### PR TITLE
feat: UI size setting (Regular/Large/Xtra-Large)

### DIFF
--- a/app/src/app/actions/profile.ts
+++ b/app/src/app/actions/profile.ts
@@ -3,6 +3,7 @@
 import { cookies } from 'next/headers'
 import { createSupabaseServerClient } from '@/lib/supabase/server'
 import { isThemePreference, THEME_COOKIE, type ThemePreference } from '@/lib/theme'
+import { isUiSizePreference, UI_SIZE_COOKIE, type UiSizePreference } from '@/lib/uiSize'
 
 /**
  * updateUsernameAction — update the current user's username.
@@ -58,6 +59,39 @@ export async function updateThemePreferenceAction(
 
   const cookieStore = await cookies()
   cookieStore.set(THEME_COOKIE, preference, {
+    path: '/',
+    maxAge: 60 * 60 * 24 * 365,
+    sameSite: 'lax',
+  })
+
+  return {}
+}
+
+/**
+ * updateUiSizeAction — update the current user's ui_size preference.
+ * Mirrors the DB value into a cookie so the root layout can SSR the correct
+ * `data-size` attribute on subsequent page loads without a flash.
+ */
+export async function updateUiSizeAction(
+  preference: UiSizePreference
+): Promise<{ error?: string }> {
+  if (!isUiSizePreference(preference)) return { error: 'Invalid size.' }
+
+  const supabase = await createSupabaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return { error: 'Not authenticated.' }
+
+  const { error } = await supabase
+    .from('profiles')
+    .update({ ui_size: preference })
+    .eq('id', user.id)
+
+  if (error) return { error: error.message }
+
+  const cookieStore = await cookies()
+  cookieStore.set(UI_SIZE_COOKIE, preference, {
     path: '/',
     maxAge: 60 * 60 * 24 * 365,
     sameSite: 'lax',

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -77,6 +77,14 @@ html {
   height: 100%;
 }
 
+html[data-size="large"] {
+  font-size: 18.4px; /* 115% of 16px — scales all rem-based text */
+}
+
+html[data-size="xlarge"] {
+  font-size: 20.8px; /* 130% of 16px — scales all rem-based text */
+}
+
 html,
 body {
   max-width: 100vw;

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { cookies } from 'next/headers'
 import { isThemePreference, THEME_COOKIE, type ThemePreference } from '@/lib/theme'
+import { isUiSizePreference, UI_SIZE_COOKIE, type UiSizePreference } from '@/lib/uiSize'
 import './globals.css'
 
 export const metadata: Metadata = {
@@ -16,9 +17,11 @@ export default async function RootLayout({
   const cookieStore = await cookies()
   const stored = cookieStore.get(THEME_COOKIE)?.value
   const theme: ThemePreference = isThemePreference(stored) ? stored : 'system'
+  const storedSize = cookieStore.get(UI_SIZE_COOKIE)?.value
+  const uiSize: UiSizePreference = isUiSizePreference(storedSize) ? storedSize : 'regular'
 
   return (
-    <html lang="en" data-theme={theme} suppressHydrationWarning>
+    <html lang="en" data-theme={theme} data-size={uiSize} suppressHydrationWarning>
       <body>{children}</body>
     </html>
   )

--- a/app/src/app/settings/page.tsx
+++ b/app/src/app/settings/page.tsx
@@ -12,7 +12,7 @@ export default async function SettingsPageRoute() {
 
   const { data: profile } = await supabase
     .from('profiles')
-    .select('username, theme_preference')
+    .select('username, theme_preference, ui_size')
     .eq('id', user.id)
     .single()
 
@@ -20,6 +20,7 @@ export default async function SettingsPageRoute() {
     <SettingsPage
       username={profile?.username ?? ''}
       themePreference={profile?.theme_preference ?? 'system'}
+      uiSizePreference={profile?.ui_size ?? 'regular'}
     />
   )
 }

--- a/app/src/components/settings/SettingsPage.tsx
+++ b/app/src/components/settings/SettingsPage.tsx
@@ -2,13 +2,15 @@
 
 import { useState } from 'react'
 import PageNav from '@/components/shared/PageNav'
-import { updateUsernameAction, updateThemePreferenceAction } from '@/app/actions/profile'
+import { updateUsernameAction, updateThemePreferenceAction, updateUiSizeAction } from '@/app/actions/profile'
 import { applyTheme, type ThemePreference } from '@/lib/theme'
+import { applyUiSize, type UiSizePreference } from '@/lib/uiSize'
 import styles from './settings.module.css'
 
 interface SettingsPageProps {
   username: string
   themePreference: ThemePreference
+  uiSizePreference: UiSizePreference
 }
 
 const THEME_OPTIONS: { value: ThemePreference; label: string }[] = [
@@ -17,9 +19,16 @@ const THEME_OPTIONS: { value: ThemePreference; label: string }[] = [
   { value: 'system', label: 'System' },
 ]
 
+const SIZE_OPTIONS: { value: UiSizePreference; label: string }[] = [
+  { value: 'regular', label: 'Regular' },
+  { value: 'large', label: 'Large' },
+  { value: 'xlarge', label: 'Xtra-Large' },
+]
+
 export default function SettingsPage({
   username: initialUsername,
   themePreference: initialTheme,
+  uiSizePreference: initialSize,
 }: SettingsPageProps) {
   const [username, setUsername] = useState(initialUsername)
   const [saving, setSaving] = useState(false)
@@ -27,6 +36,9 @@ export default function SettingsPage({
 
   const [theme, setTheme] = useState<ThemePreference>(initialTheme)
   const [themeFeedback, setThemeFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null)
+
+  const [uiSize, setUiSize] = useState<UiSizePreference>(initialSize)
+  const [sizeFeedback, setSizeFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null)
 
   async function handleSave(e: React.FormEvent) {
     e.preventDefault()
@@ -38,6 +50,23 @@ export default function SettingsPage({
       setFeedback({ type: 'error', message: result.error })
     } else {
       setFeedback({ type: 'success', message: 'Username updated.' })
+    }
+  }
+
+  async function handleSizeSelect(next: UiSizePreference) {
+    if (next === uiSize) return
+    const previous = uiSize
+    setUiSize(next)
+    setSizeFeedback(null)
+    applyUiSize(next)
+
+    const result = await updateUiSizeAction(next)
+    if (result.error) {
+      setUiSize(previous)
+      applyUiSize(previous)
+      setSizeFeedback({ type: 'error', message: result.error })
+    } else {
+      setSizeFeedback({ type: 'success', message: 'Size saved.' })
     }
   }
 
@@ -106,6 +135,32 @@ export default function SettingsPage({
           {themeFeedback && (
             <p className={`${styles.feedback} ${themeFeedback.type === 'success' ? styles.feedbackSuccess : styles.feedbackError}`}>
               {themeFeedback.message}
+            </p>
+          )}
+        </section>
+
+        <section className={styles.themeSection} aria-labelledby="size-label">
+          <span id="size-label" className={styles.fieldLabel}>Text size</span>
+          <div className={styles.segmented} role="radiogroup" aria-labelledby="size-label">
+            {SIZE_OPTIONS.map((opt) => {
+              const selected = uiSize === opt.value
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  role="radio"
+                  aria-checked={selected}
+                  className={`${styles.segmentBtn} ${selected ? styles.segmentBtnActive : ''}`}
+                  onClick={() => handleSizeSelect(opt.value)}
+                >
+                  {opt.label}
+                </button>
+              )
+            })}
+          </div>
+          {sizeFeedback && (
+            <p className={`${styles.feedback} ${sizeFeedback.type === 'success' ? styles.feedbackSuccess : styles.feedbackError}`}>
+              {sizeFeedback.message}
             </p>
           )}
         </section>

--- a/app/src/hooks/useUiSize.ts
+++ b/app/src/hooks/useUiSize.ts
@@ -1,0 +1,30 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { UI_SIZE_EVENT, isUiSizePreference, type UiSizePreference } from '@/lib/uiSize'
+
+function readAttribute(): UiSizePreference {
+  if (typeof document === 'undefined') return 'regular'
+  const attr = document.documentElement.dataset.size
+  return isUiSizePreference(attr) ? attr : 'regular'
+}
+
+export function useUiSize(): UiSizePreference {
+  const [size, setSize] = useState<UiSizePreference>(readAttribute)
+
+  useEffect(() => {
+    setSize(readAttribute())
+
+    const onSizeChange = (e: Event) => {
+      const detail = (e as CustomEvent<UiSizePreference>).detail
+      if (isUiSizePreference(detail)) setSize(detail)
+    }
+    window.addEventListener(UI_SIZE_EVENT, onSizeChange)
+
+    return () => {
+      window.removeEventListener(UI_SIZE_EVENT, onSizeChange)
+    }
+  }, [])
+
+  return size
+}

--- a/app/src/lib/uiSize.ts
+++ b/app/src/lib/uiSize.ts
@@ -1,0 +1,16 @@
+export type UiSizePreference = 'regular' | 'large' | 'xlarge'
+
+export const UI_SIZE_COOKIE = 'ui-size'
+export const UI_SIZE_EVENT = 'uisizechange'
+export const UI_SIZE_PREFERENCES: readonly UiSizePreference[] = ['regular', 'large', 'xlarge']
+
+export function isUiSizePreference(value: unknown): value is UiSizePreference {
+  return typeof value === 'string' && (UI_SIZE_PREFERENCES as readonly string[]).includes(value)
+}
+
+export function applyUiSize(pref: UiSizePreference): void {
+  if (typeof document === 'undefined') return
+  document.documentElement.dataset.size = pref
+  document.cookie = `${UI_SIZE_COOKIE}=${pref}; path=/; max-age=${60 * 60 * 24 * 365}; samesite=lax`
+  window.dispatchEvent(new CustomEvent<UiSizePreference>(UI_SIZE_EVENT, { detail: pref }))
+}

--- a/app/supabase/migrations/0014_profile_ui_size.sql
+++ b/app/supabase/migrations/0014_profile_ui_size.sql
@@ -1,0 +1,4 @@
+-- Issue #42: UI size toggle — persist user's size preference
+alter table public.profiles
+  add column ui_size text not null default 'regular'
+  check (ui_size in ('regular', 'large', 'xlarge'));

--- a/app/tests/integration/profile/uiSize.test.ts
+++ b/app/tests/integration/profile/uiSize.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Settings / UI size preference — Issue #42
+ *
+ * Verifies DB-level behaviour for UI size persistence:
+ * S42-1  User can update their own ui_size
+ * S42-2  Invalid value rejected by check constraint
+ * S42-3  Non-owner cannot update another user's ui_size (RLS)
+ * S42-4  Default value for new users is 'regular'
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { createUser, signIn, cleanupUsers, admin } from '../helpers/seed'
+
+let userId: string
+let otherUserId: string
+let userClient: SupabaseClient
+let otherClient: SupabaseClient
+
+beforeAll(async () => {
+  const user = await createUser('s42-user')
+  const other = await createUser('s42-other')
+
+  userId = user.id
+  otherUserId = other.id
+
+  userClient = await signIn(user.email, user.password)
+  otherClient = await signIn(other.email, other.password)
+})
+
+afterAll(async () => {
+  await cleanupUsers([userId, otherUserId])
+})
+
+// ---------------------------------------------------------------------------
+// S42-1: User can update their own ui_size
+// ---------------------------------------------------------------------------
+describe('S42-1: user updates own ui_size', () => {
+  it('UPDATE succeeds and row reflects new value', async () => {
+    const { error } = await userClient
+      .from('profiles')
+      .update({ ui_size: 'large' })
+      .eq('id', userId)
+
+    expect(error).toBeNull()
+
+    const { data } = await admin
+      .from('profiles')
+      .select('ui_size')
+      .eq('id', userId)
+      .single()
+
+    expect(data!.ui_size).toBe('large')
+  })
+
+  it('UPDATE to xlarge succeeds', async () => {
+    const { error } = await userClient
+      .from('profiles')
+      .update({ ui_size: 'xlarge' })
+      .eq('id', userId)
+
+    expect(error).toBeNull()
+
+    const { data } = await admin
+      .from('profiles')
+      .select('ui_size')
+      .eq('id', userId)
+      .single()
+
+    expect(data!.ui_size).toBe('xlarge')
+  })
+
+  it('UPDATE back to regular succeeds', async () => {
+    const { error } = await userClient
+      .from('profiles')
+      .update({ ui_size: 'regular' })
+      .eq('id', userId)
+
+    expect(error).toBeNull()
+
+    const { data } = await admin
+      .from('profiles')
+      .select('ui_size')
+      .eq('id', userId)
+      .single()
+
+    expect(data!.ui_size).toBe('regular')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// S42-2: Invalid ui_size value rejected by check constraint
+// ---------------------------------------------------------------------------
+describe('S42-2: invalid value rejected', () => {
+  it('UPDATE with invalid size returns a check constraint error', async () => {
+    const { error } = await userClient
+      .from('profiles')
+      .update({ ui_size: 'huge' })
+      .eq('id', userId)
+
+    expect(error).not.toBeNull()
+    // Postgres check_violation = code 23514
+    expect(error!.code).toBe('23514')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// S42-3: Non-owner cannot update another user's ui_size (RLS)
+// ---------------------------------------------------------------------------
+describe('S42-3: non-owner cannot update another profile', () => {
+  it('UPDATE on another row is blocked by RLS (0 rows affected, no error)', async () => {
+    // Seed a known baseline via admin
+    await admin.from('profiles').update({ ui_size: 'regular' }).eq('id', userId)
+
+    const { error } = await otherClient
+      .from('profiles')
+      .update({ ui_size: 'large' })
+      .eq('id', userId)
+
+    expect(error).toBeNull()
+
+    const { data } = await admin
+      .from('profiles')
+      .select('ui_size')
+      .eq('id', userId)
+      .single()
+
+    expect(data!.ui_size).toBe('regular')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// S42-4: Default for new users is 'regular'
+// ---------------------------------------------------------------------------
+describe('S42-4: default ui_size is regular', () => {
+  it('freshly created profile has ui_size = regular', async () => {
+    const { data } = await admin
+      .from('profiles')
+      .select('ui_size')
+      .eq('id', otherUserId)
+      .single()
+
+    expect(data!.ui_size).toBe('regular')
+  })
+})


### PR DESCRIPTION
## Summary
- Adds Text Size setting in Settings page with three options: Regular, Large, Xtra-Large
- Scales all rem-based text globally by overriding `html[data-size]` font-size — zero CSS module changes needed
- Stored in `profiles.ui_size` DB column + `ui-size` cookie for flash-free SSR (same pattern as theme toggle)
- New `lib/uiSize.ts` and `hooks/useUiSize.ts` mirror `lib/theme.ts` / `hooks/useTheme.ts` exactly
- Integration tests cover DB constraint, RLS, and default value

## Closes
#42

## Human QA steps
- [ ] Go to `/settings` — confirm "Text size" segmented control appears below "Theme"
- [ ] Click **Large** — nav links and button text should visibly grow immediately, no reload
- [ ] Click **Xtra-Large** — text should grow further
- [ ] Click **Regular** — text should return to default; confirm it matches other browsers where no size is set
- [ ] Hard-reload the page after selecting Large — size should be preserved (no flash)
- [ ] Open a private window (clears cookies); log in — DB value should restore your size preference
- [ ] Edge case: open DevTools → Application → Cookies → delete `ui-size` cookie, reload — should fall back to Regular

🤖 Generated with [Claude Code](https://claude.com/claude-code)