### PR TITLE
feat: default theme to dark

### DIFF
--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -16,7 +16,7 @@ export default async function RootLayout({
 }>) {
   const cookieStore = await cookies()
   const stored = cookieStore.get(THEME_COOKIE)?.value
-  const theme: ThemePreference = isThemePreference(stored) ? stored : 'system'
+  const theme: ThemePreference = isThemePreference(stored) ? stored : 'dark'
   const storedSize = cookieStore.get(UI_SIZE_COOKIE)?.value
   const uiSize: UiSizePreference = isUiSizePreference(storedSize) ? storedSize : 'regular'
 

--- a/app/src/app/settings/page.tsx
+++ b/app/src/app/settings/page.tsx
@@ -19,7 +19,7 @@ export default async function SettingsPageRoute() {
   return (
     <SettingsPage
       username={profile?.username ?? ''}
-      themePreference={profile?.theme_preference ?? 'system'}
+      themePreference={profile?.theme_preference ?? 'dark'}
       uiSizePreference={profile?.ui_size ?? 'regular'}
     />
   )


### PR DESCRIPTION
## Summary
- New users (no cookie) now get dark theme instead of system default
- Settings page shows dark as selected when profile has no stored preference

## Closes
#48

## Human QA steps
- [ ] Clear all cookies, open app — verify dark map tiles and dark UI render
- [ ] Open Settings — verify "Dark" segment is selected by default (not "System")
- [ ] Change to Light, save, reload — verify Light persists (cookie respected over new default)
- [ ] Change back to Dark, save, reload — verify Dark persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)