### PR TITLE
feat: align network page UI with design system

### DIFF
--- a/app/src/app/networks/[id]/generate-invite-form.tsx
+++ b/app/src/app/networks/[id]/generate-invite-form.tsx
@@ -2,6 +2,7 @@
 
 import { useActionState } from 'react'
 import { createInvitationAction } from '@/app/actions/invitations'
+import styles from './networkDetail.module.css'
 
 interface Props {
   networkId: string
@@ -21,16 +22,16 @@ export default function GenerateInviteForm({ networkId }: Props) {
     <div>
       <form action={action}>
         <input type="hidden" name="network_id" value={networkId} />
-        <button type="submit" disabled={pending}>
-          {pending ? 'Generating…' : 'Generate invite link'}
+        <button type="submit" disabled={pending} className={styles.generateBtn}>
+          {pending ? 'Generating\u2026' : 'Generate invite link'}
         </button>
       </form>
-      {state?.error && <p role="alert">{state.error}</p>}
+      {state?.error && <p role="alert" className={styles.formError}>{state.error}</p>}
       {inviteUrl && (
-        <p>
-          <span>Invite link: </span>
-          <code>{inviteUrl}</code>
-        </p>
+        <div>
+          <p className={styles.inviteUrlLabel}>Invite link</p>
+          <code className={styles.inviteUrl}>{inviteUrl}</code>
+        </div>
       )}
     </div>
   )

--- a/app/src/app/networks/[id]/networkDetail.module.css
+++ b/app/src/app/networks/[id]/networkDetail.module.css
@@ -1,0 +1,300 @@
+.page {
+  min-height: 100vh;
+  background: var(--paper);
+  color: var(--ink);
+}
+
+.header {
+  padding: 32px 24px 24px;
+  border-bottom: 1px solid var(--rule);
+  background: var(--modal-bg);
+}
+
+.title {
+  font-family: var(--font-serif);
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--ink);
+  letter-spacing: 0.01em;
+  margin: 0 0 6px;
+}
+
+.subtitle {
+  font-family: var(--font-serif);
+  font-size: 0.85rem;
+  font-weight: 300;
+  color: var(--ink-faint);
+  letter-spacing: 0.04em;
+}
+
+.section {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 24px 24px 0;
+}
+
+.section:last-child {
+  padding-bottom: 48px;
+}
+
+.sectionLabel {
+  font-family: var(--font-serif);
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink-faint);
+  margin-bottom: 0;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.fieldLabel {
+  display: block;
+  font-family: var(--font-serif);
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink-faint);
+  margin-bottom: 8px;
+}
+
+.input {
+  width: 100%;
+  box-sizing: border-box;
+  font-family: var(--font-serif);
+  font-size: 0.95rem;
+  font-weight: 400;
+  color: var(--ink);
+  background: var(--modal-bg);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  padding: 10px 12px;
+  outline: none;
+  transition: border-color 160ms;
+}
+
+.input:focus {
+  border-color: var(--tan);
+}
+
+.saveBtn {
+  margin-top: 16px;
+  font-family: var(--font-serif);
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--modal-bg);
+  background: var(--accent);
+  border: none;
+  border-radius: var(--radius);
+  padding: 9px 22px;
+  cursor: pointer;
+  letter-spacing: 0.04em;
+  transition: opacity 160ms;
+}
+
+.saveBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.saveBtn:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.generateBtn {
+  font-family: var(--font-serif);
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--modal-bg);
+  background: var(--accent);
+  border: none;
+  border-radius: var(--radius);
+  padding: 9px 22px;
+  cursor: pointer;
+  letter-spacing: 0.04em;
+  transition: opacity 160ms;
+}
+
+.generateBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.generateBtn:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.formError {
+  margin-top: 12px;
+  font-family: var(--font-serif);
+  font-size: 0.85rem;
+  font-weight: 300;
+  color: #b04030;
+}
+
+.memberList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.memberItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+.memberItem:last-child {
+  border-bottom: none;
+}
+
+.memberName {
+  font-family: var(--font-serif);
+  font-size: 0.9rem;
+  font-weight: 400;
+  color: var(--ink);
+}
+
+.memberRole {
+  font-family: var(--font-serif);
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: var(--ink-faint);
+  letter-spacing: 0.04em;
+}
+
+.inlineForm {
+  display: inline-flex;
+  margin-left: auto;
+}
+
+.inlineBtn {
+  font-family: var(--font-serif);
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: var(--ink-faint);
+  background: none;
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  padding: 4px 10px;
+  cursor: pointer;
+  transition: color 160ms, border-color 160ms;
+}
+
+.inlineBtn:hover {
+  color: #b04030;
+  border-color: #b04030;
+}
+
+.inviteList {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+}
+
+.inviteItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+.inviteItem:last-child {
+  border-bottom: none;
+}
+
+.inviteExpiry {
+  font-family: var(--font-serif);
+  font-size: 0.8rem;
+  font-weight: 300;
+  color: var(--ink-faint);
+}
+
+.inviteUrl {
+  display: block;
+  margin-top: 12px;
+  font-family: monospace;
+  font-size: 0.8rem;
+  color: var(--ink);
+  background: var(--tan-light);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  padding: 8px 12px;
+  word-break: break-all;
+}
+
+.inviteUrlLabel {
+  font-family: var(--font-serif);
+  font-size: 0.8rem;
+  font-weight: 300;
+  color: var(--ink-faint);
+  margin-top: 12px;
+}
+
+.dangerSection {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 24px 24px 48px;
+}
+
+.dangerBtn {
+  font-family: var(--font-serif);
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #fff;
+  background: #b04030;
+  border: none;
+  border-radius: var(--radius);
+  padding: 9px 22px;
+  cursor: pointer;
+  letter-spacing: 0.04em;
+  transition: opacity 160ms;
+}
+
+.dangerBtn:hover {
+  opacity: 0.85;
+}
+
+.leaveBtn {
+  font-family: var(--font-serif);
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--ink-faint);
+  background: none;
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  padding: 9px 22px;
+  cursor: pointer;
+  letter-spacing: 0.04em;
+  transition: color 160ms, border-color 160ms;
+}
+
+.leaveBtn:hover {
+  color: #b04030;
+  border-color: #b04030;
+}
+
+.emptyState {
+  font-family: var(--font-serif);
+  font-size: 0.9rem;
+  font-weight: 300;
+  color: var(--ink-faint);
+  padding: 24px 0;
+  font-style: italic;
+}
+
+@media (max-width: 480px) {
+  .header {
+    padding: 24px 16px 20px;
+  }
+  .section,
+  .dangerSection {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+}

--- a/app/src/app/networks/[id]/page.tsx
+++ b/app/src/app/networks/[id]/page.tsx
@@ -7,7 +7,9 @@ import {
   removeMemberAction,
 } from '@/app/actions/networks'
 import { revokeInvitationAction } from '@/app/actions/invitations'
+import PageNav from '@/components/shared/PageNav'
 import GenerateInviteForm from './generate-invite-form'
+import styles from './networkDetail.module.css'
 
 interface Props {
   params: Promise<{ id: string }>
@@ -41,7 +43,7 @@ export default async function NetworkDetailPage({ params }: Props) {
     .from('memberships')
     .select('role, user_id, profiles(username)')
     .eq('network_id', id)
-    .order('role', { ascending: false }) // 'owner' before 'member'
+    .order('role', { ascending: false })
 
   const { data: activeInvitations } = await supabase
     .from('invitations')
@@ -55,86 +57,93 @@ export default async function NetworkDetailPage({ params }: Props) {
   const isOwner = network.owner_id === user!.id
 
   return (
-    <main>
-      <nav>
-        <a href="/networks">← Networks</a>
-      </nav>
+    <div className={styles.page}>
+      <PageNav />
 
-      <h1>{network.name}</h1>
+      <header className={styles.header}>
+        <h1 className={styles.title}>{network.name}</h1>
+        <p className={styles.subtitle}>
+          {members.length} member{members.length === 1 ? '' : 's'}
+        </p>
+      </header>
 
       {isOwner && (
-        <section>
-          <h2>Rename</h2>
+        <section className={styles.section}>
+          <p className={styles.sectionLabel}>Rename</p>
           <form action={renameNetworkAction}>
             <input type="hidden" name="network_id" value={id} />
-            <label htmlFor="rename-input">New name</label>
+            <label htmlFor="rename-input" className={styles.fieldLabel}>New name</label>
             <input
               id="rename-input"
               name="name"
               type="text"
               defaultValue={network.name}
               required
+              className={styles.input}
               suppressHydrationWarning
             />
-            <button type="submit">Save</button>
+            <button type="submit" className={styles.saveBtn}>Save</button>
           </form>
         </section>
       )}
 
-      <section>
-        <h2>Invite Members</h2>
+      <section className={styles.section}>
+        <p className={styles.sectionLabel}>Invitations</p>
         <GenerateInviteForm networkId={id} />
         {isOwner && activeInvitations && activeInvitations.length > 0 && (
-          <div>
-            <h3>Active invite links</h3>
-            <ul>
-              {activeInvitations.map((inv) => (
-                <li key={inv.id}>
-                  <span>Expires: {new Date(inv.expires_at).toLocaleDateString()}</span>
-                  <form action={revokeInvitationAction} style={{ display: 'inline', marginLeft: '0.5rem' }}>
-                    <input type="hidden" name="invitation_id" value={inv.id} />
-                    <input type="hidden" name="network_id" value={id} />
-                    <button type="submit">Revoke</button>
-                  </form>
-                </li>
-              ))}
-            </ul>
-          </div>
+          <ul className={styles.inviteList}>
+            {activeInvitations.map((inv) => (
+              <li key={inv.id} className={styles.inviteItem}>
+                <span className={styles.inviteExpiry}>
+                  Expires {new Date(inv.expires_at).toLocaleDateString()}
+                </span>
+                <form action={revokeInvitationAction} className={styles.inlineForm}>
+                  <input type="hidden" name="invitation_id" value={inv.id} />
+                  <input type="hidden" name="network_id" value={id} />
+                  <button type="submit" className={styles.inlineBtn}>Revoke</button>
+                </form>
+              </li>
+            ))}
+          </ul>
         )}
       </section>
 
-      <section>
-        <h2>Members</h2>
-        <ul>
-          {members.map((m) => (
-            <li key={m.user_id}>
-              <span>{m.profiles?.username ?? m.user_id}</span>
-              <span> — {m.role}</span>
-              {isOwner && m.user_id !== user!.id && (
-                <form action={removeMemberAction} style={{ display: 'inline', marginLeft: '0.5rem' }}>
-                  <input type="hidden" name="network_id" value={id} />
-                  <input type="hidden" name="user_id" value={m.user_id} />
-                  <button type="submit">Remove</button>
-                </form>
-              )}
-            </li>
-          ))}
-        </ul>
+      <section className={styles.section}>
+        <p className={styles.sectionLabel}>Members</p>
+        {members.length > 0 ? (
+          <ul className={styles.memberList}>
+            {members.map((m) => (
+              <li key={m.user_id} className={styles.memberItem}>
+                <span className={styles.memberName}>{m.profiles?.username ?? m.user_id}</span>
+                <span className={styles.memberRole}>{m.role}</span>
+                {isOwner && m.user_id !== user!.id && (
+                  <form action={removeMemberAction} className={styles.inlineForm}>
+                    <input type="hidden" name="network_id" value={id} />
+                    <input type="hidden" name="user_id" value={m.user_id} />
+                    <button type="submit" className={styles.inlineBtn}>Remove</button>
+                  </form>
+                )}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className={styles.emptyState}>No members yet.</p>
+        )}
       </section>
 
-      <section>
+      <section className={styles.dangerSection}>
         {isOwner ? (
           <form action={deleteNetworkAction}>
             <input type="hidden" name="network_id" value={id} />
-            <button type="submit">Delete Network</button>
+            <button type="submit" className={styles.dangerBtn}>Delete Network</button>
           </form>
         ) : (
           <form action={leaveNetworkAction}>
             <input type="hidden" name="network_id" value={id} />
-            <button type="submit">Leave Network</button>
+            <button type="submit" className={styles.leaveBtn}>Leave Network</button>
           </form>
         )}
       </section>
-    </main>
+    </div>
   )
 }

--- a/app/src/app/networks/create-network-form.tsx
+++ b/app/src/app/networks/create-network-form.tsx
@@ -2,17 +2,26 @@
 
 import { useActionState } from 'react'
 import { createNetworkAction } from '@/app/actions/networks'
+import styles from './networks.module.css'
 
 export default function CreateNetworkForm() {
   const [state, action, pending] = useActionState(createNetworkAction, undefined)
 
   return (
     <form action={action}>
-      <label htmlFor="network-name">Network name</label>
-      <input id="network-name" name="name" type="text" required placeholder="e.g. Trail Crew" suppressHydrationWarning />
-      {state?.error && <p role="alert">{state.error}</p>}
-      <button type="submit" disabled={pending} suppressHydrationWarning>
-        {pending ? 'Creating…' : 'Create Network'}
+      <label htmlFor="network-name" className={styles.fieldLabel}>Network name</label>
+      <input
+        id="network-name"
+        name="name"
+        type="text"
+        required
+        placeholder="e.g. Trail Crew"
+        className={styles.input}
+        suppressHydrationWarning
+      />
+      {state?.error && <p role="alert" className={styles.formError}>{state.error}</p>}
+      <button type="submit" disabled={pending} className={styles.createBtn} suppressHydrationWarning>
+        {pending ? 'Creating\u2026' : 'Create Network'}
       </button>
     </form>
   )

--- a/app/src/app/networks/networks.module.css
+++ b/app/src/app/networks/networks.module.css
@@ -1,0 +1,166 @@
+.page {
+  min-height: 100vh;
+  background: var(--paper);
+  color: var(--ink);
+}
+
+.header {
+  padding: 32px 24px 24px;
+  border-bottom: 1px solid var(--rule);
+  background: var(--modal-bg);
+}
+
+.title {
+  font-family: var(--font-serif);
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--ink);
+  letter-spacing: 0.01em;
+  margin: 0 0 6px;
+}
+
+.subtitle {
+  font-family: var(--font-serif);
+  font-size: 0.85rem;
+  font-weight: 300;
+  color: var(--ink-faint);
+  letter-spacing: 0.04em;
+}
+
+.section {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 24px 24px 48px;
+}
+
+.sectionLabel {
+  font-family: var(--font-serif);
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink-faint);
+  margin-bottom: 0;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.networkList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.networkItem {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+.networkItem:last-child {
+  border-bottom: none;
+}
+
+.networkLink {
+  font-family: var(--font-serif);
+  font-size: 0.9rem;
+  font-weight: 400;
+  color: var(--sepia);
+  text-decoration: none;
+  letter-spacing: 0.01em;
+  transition: color 160ms;
+}
+
+.networkLink:hover {
+  color: var(--accent);
+}
+
+.ownerBadge {
+  font-family: var(--font-serif);
+  font-size: 0.7rem;
+  font-weight: 400;
+  color: var(--ink-faint);
+  letter-spacing: 0.04em;
+}
+
+.emptyState {
+  font-family: var(--font-serif);
+  font-size: 0.9rem;
+  font-weight: 300;
+  color: var(--ink-faint);
+  padding: 24px 0;
+  font-style: italic;
+}
+
+.fieldLabel {
+  display: block;
+  font-family: var(--font-serif);
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink-faint);
+  margin-bottom: 8px;
+}
+
+.input {
+  width: 100%;
+  box-sizing: border-box;
+  font-family: var(--font-serif);
+  font-size: 0.95rem;
+  font-weight: 400;
+  color: var(--ink);
+  background: var(--modal-bg);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  padding: 10px 12px;
+  outline: none;
+  transition: border-color 160ms;
+}
+
+.input:focus {
+  border-color: var(--tan);
+}
+
+.createBtn {
+  margin-top: 16px;
+  font-family: var(--font-serif);
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--modal-bg);
+  background: var(--accent);
+  border: none;
+  border-radius: var(--radius);
+  padding: 9px 22px;
+  cursor: pointer;
+  letter-spacing: 0.04em;
+  transition: opacity 160ms;
+}
+
+.createBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.createBtn:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.formError {
+  margin-top: 12px;
+  font-family: var(--font-serif);
+  font-size: 0.85rem;
+  font-weight: 300;
+  color: #b04030;
+}
+
+@media (max-width: 480px) {
+  .header {
+    padding: 24px 16px 20px;
+  }
+  .section {
+    padding: 20px 16px 40px;
+  }
+}

--- a/app/src/app/networks/page.tsx
+++ b/app/src/app/networks/page.tsx
@@ -1,5 +1,7 @@
 import { createSupabaseServerClient } from '@/lib/supabase/server'
+import PageNav from '@/components/shared/PageNav'
 import CreateNetworkForm from './create-network-form'
+import styles from './networks.module.css'
 
 export default async function NetworksPage() {
   const supabase = await createSupabaseServerClient()
@@ -13,33 +15,39 @@ export default async function NetworksPage() {
     .select('id, name, owner_id')
     .order('created_at', { ascending: false })
 
+  const count = networks?.length ?? 0
+
   return (
-    <main>
-      <header>
-        <a href="/">← Home</a>
-        <h1>Networks</h1>
+    <div className={styles.page}>
+      <PageNav />
+
+      <header className={styles.header}>
+        <h1 className={styles.title}>Networks</h1>
+        <p className={styles.subtitle}>
+          {count === 0 ? 'No networks yet' : `${count} network${count === 1 ? '' : 's'}`}
+        </p>
       </header>
 
-      <section>
-        <h2>Create a Network</h2>
+      <section className={styles.section}>
+        <p className={styles.sectionLabel}>Create a Network</p>
         <CreateNetworkForm />
       </section>
 
-      <section>
-        <h2>Your Networks</h2>
+      <section className={styles.section}>
+        <p className={styles.sectionLabel}>Your Networks</p>
         {networks && networks.length > 0 ? (
-          <ul>
+          <ul className={styles.networkList}>
             {networks.map((n) => (
-              <li key={n.id}>
-                <a href={`/networks/${n.id}`}>{n.name}</a>
-                {n.owner_id === user!.id && <span> (owner)</span>}
+              <li key={n.id} className={styles.networkItem}>
+                <a href={`/networks/${n.id}`} className={styles.networkLink}>{n.name}</a>
+                {n.owner_id === user!.id && <span className={styles.ownerBadge}>owner</span>}
               </li>
             ))}
           </ul>
         ) : (
-          <p>No networks yet. Create one above.</p>
+          <p className={styles.emptyState}>No networks yet. Create one above.</p>
         )}
       </section>
-    </main>
+    </div>
   )
 }

--- a/app/src/components/map/MapPage.tsx
+++ b/app/src/components/map/MapPage.tsx
@@ -354,6 +354,7 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
             Explore
           </button>
           <a href="/profile" className={styles.panelNavLink}>Profile</a>
+          <a href="/networks" className={styles.panelNavLink}>Networks</a>
           <a href="/settings" className={styles.panelNavLink}>Settings</a>
         </div>
       </aside>

--- a/app/src/components/shared/PageNav.tsx
+++ b/app/src/components/shared/PageNav.tsx
@@ -8,6 +8,7 @@ import styles from './pageNav.module.css'
 const LINKS = [
   { href: '/', label: 'Map' },
   { href: '/profile', label: 'Profile' },
+  { href: '/networks', label: 'Networks' },
   { href: '/settings', label: 'Settings' },
 ]
 


### PR DESCRIPTION
## Summary
- Add "Networks" link to PageNav (top nav) and MapPage side panel nav
- Restyle `/networks` list page with CSS Modules, PageNav, header, styled sections and forms
- Restyle `/networks/[id]` detail page — members list, invitations, rename form, danger zone actions
- Both pages now match profile/settings design patterns (design tokens, typography, spacing)

Closes #50

## Test plan
- [ ] Visit `/networks` — PageNav visible with 4 links, styled create form and network list
- [ ] Visit `/networks/[id]` — PageNav visible, styled sections for rename/invitations/members/delete
- [ ] Visit `/profile` and `/settings` — PageNav shows Networks link
- [ ] Open map side panel — Networks link between Profile and Settings
- [ ] Check dark mode on both network pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)