### PR TITLE
fix: remove redundant labels from network pages

### DIFF
--- a/app/src/app/networks/[id]/page.tsx
+++ b/app/src/app/networks/[id]/page.tsx
@@ -69,10 +69,8 @@ export default async function NetworkDetailPage({ params }: Props) {
 
       {isOwner && (
         <section className={styles.section}>
-          <p className={styles.sectionLabel}>Rename</p>
           <form action={renameNetworkAction}>
             <input type="hidden" name="network_id" value={id} />
-            <label htmlFor="rename-input" className={styles.fieldLabel}>New name</label>
             <input
               id="rename-input"
               name="name"
@@ -88,7 +86,6 @@ export default async function NetworkDetailPage({ params }: Props) {
       )}
 
       <section className={styles.section}>
-        <p className={styles.sectionLabel}>Invitations</p>
         <GenerateInviteForm networkId={id} />
         {isOwner && activeInvitations && activeInvitations.length > 0 && (
           <ul className={styles.inviteList}>

--- a/app/src/app/networks/create-network-form.tsx
+++ b/app/src/app/networks/create-network-form.tsx
@@ -9,7 +9,6 @@ export default function CreateNetworkForm() {
 
   return (
     <form action={action}>
-      <label htmlFor="network-name" className={styles.fieldLabel}>Network name</label>
       <input
         id="network-name"
         name="name"
@@ -21,7 +20,7 @@ export default function CreateNetworkForm() {
       />
       {state?.error && <p role="alert" className={styles.formError}>{state.error}</p>}
       <button type="submit" disabled={pending} className={styles.createBtn} suppressHydrationWarning>
-        {pending ? 'Creating\u2026' : 'Create Network'}
+        {pending ? 'Creating\u2026' : 'Create New Network'}
       </button>
     </form>
   )

--- a/app/src/app/networks/page.tsx
+++ b/app/src/app/networks/page.tsx
@@ -29,7 +29,6 @@ export default async function NetworksPage() {
       </header>
 
       <section className={styles.section}>
-        <p className={styles.sectionLabel}>Create a Network</p>
         <CreateNetworkForm />
       </section>
 


### PR DESCRIPTION
## Summary
- Remove "Create a Network" and "Network name" labels from networks list page
- Rename button from "Create Network" to "Create New Network"
- Remove "Rename", "New name", and "Invitations" labels from network detail page

Follow-up to #55

## Test plan
- [ ] `/networks` — input with no labels, button says "Create New Network"
- [ ] `/networks/[id]` — rename input and invite button have no headers above them

🤖 Generated with [Claude Code](https://claude.com/claude-code)