### PR TITLE
feat: rename UI size tiers and add XXL option

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -77,12 +77,16 @@ html {
   height: 100%;
 }
 
-html[data-size="large"] {
+html[data-size="medium"] {
   font-size: 18.4px; /* 115% of 16px — scales all rem-based text */
 }
 
-html[data-size="xlarge"] {
+html[data-size="xl"] {
   font-size: 20.8px; /* 130% of 16px — scales all rem-based text */
+}
+
+html[data-size="xxl"] {
+  font-size: 23.2px; /* 145% of 16px — scales all rem-based text */
 }
 
 html,

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -18,7 +18,7 @@ export default async function RootLayout({
   const stored = cookieStore.get(THEME_COOKIE)?.value
   const theme: ThemePreference = isThemePreference(stored) ? stored : 'dark'
   const storedSize = cookieStore.get(UI_SIZE_COOKIE)?.value
-  const uiSize: UiSizePreference = isUiSizePreference(storedSize) ? storedSize : 'regular'
+  const uiSize: UiSizePreference = isUiSizePreference(storedSize) ? storedSize : 'medium'
 
   return (
     <html lang="en" data-theme={theme} data-size={uiSize} suppressHydrationWarning>

--- a/app/src/app/settings/page.tsx
+++ b/app/src/app/settings/page.tsx
@@ -20,7 +20,7 @@ export default async function SettingsPageRoute() {
     <SettingsPage
       username={profile?.username ?? ''}
       themePreference={profile?.theme_preference ?? 'dark'}
-      uiSizePreference={profile?.ui_size ?? 'regular'}
+      uiSizePreference={profile?.ui_size ?? 'medium'}
     />
   )
 }

--- a/app/src/components/settings/SettingsPage.tsx
+++ b/app/src/components/settings/SettingsPage.tsx
@@ -20,9 +20,10 @@ const THEME_OPTIONS: { value: ThemePreference; label: string }[] = [
 ]
 
 const SIZE_OPTIONS: { value: UiSizePreference; label: string }[] = [
-  { value: 'regular', label: 'Regular' },
-  { value: 'large', label: 'Large' },
-  { value: 'xlarge', label: 'Xtra-Large' },
+  { value: 'small', label: 'Small' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'xl', label: 'XL' },
+  { value: 'xxl', label: 'XXL' },
 ]
 
 export default function SettingsPage({

--- a/app/src/hooks/useUiSize.ts
+++ b/app/src/hooks/useUiSize.ts
@@ -4,9 +4,9 @@ import { useEffect, useState } from 'react'
 import { UI_SIZE_EVENT, isUiSizePreference, type UiSizePreference } from '@/lib/uiSize'
 
 function readAttribute(): UiSizePreference {
-  if (typeof document === 'undefined') return 'regular'
+  if (typeof document === 'undefined') return 'medium'
   const attr = document.documentElement.dataset.size
-  return isUiSizePreference(attr) ? attr : 'regular'
+  return isUiSizePreference(attr) ? attr : 'medium'
 }
 
 export function useUiSize(): UiSizePreference {

--- a/app/src/lib/uiSize.ts
+++ b/app/src/lib/uiSize.ts
@@ -1,8 +1,8 @@
-export type UiSizePreference = 'regular' | 'large' | 'xlarge'
+export type UiSizePreference = 'small' | 'medium' | 'xl' | 'xxl'
 
 export const UI_SIZE_COOKIE = 'ui-size'
 export const UI_SIZE_EVENT = 'uisizechange'
-export const UI_SIZE_PREFERENCES: readonly UiSizePreference[] = ['regular', 'large', 'xlarge']
+export const UI_SIZE_PREFERENCES: readonly UiSizePreference[] = ['small', 'medium', 'xl', 'xxl']
 
 export function isUiSizePreference(value: unknown): value is UiSizePreference {
   return typeof value === 'string' && (UI_SIZE_PREFERENCES as readonly string[]).includes(value)

--- a/app/supabase/migrations/0016_ui_size_rename_add_xxl.sql
+++ b/app/supabase/migrations/0016_ui_size_rename_add_xxl.sql
@@ -1,0 +1,20 @@
+-- Issue #52: rename ui_size tiers (regular/large/xlarge -> small/medium/xl),
+-- add xxl, and shift default to medium for new profiles.
+
+alter table public.profiles drop constraint profiles_ui_size_check;
+
+alter table public.profiles alter column ui_size drop default;
+
+update public.profiles
+  set ui_size = case ui_size
+    when 'regular' then 'small'
+    when 'large'   then 'medium'
+    when 'xlarge'  then 'xl'
+    else ui_size
+  end;
+
+alter table public.profiles alter column ui_size set default 'medium';
+
+alter table public.profiles
+  add constraint profiles_ui_size_check
+  check (ui_size in ('small', 'medium', 'xl', 'xxl'));

--- a/app/tests/integration/profile/uiSize.test.ts
+++ b/app/tests/integration/profile/uiSize.test.ts
@@ -1,11 +1,11 @@
 /**
- * Settings / UI size preference — Issue #42
+ * Settings / UI size preference — Issues #42, #52
  *
  * Verifies DB-level behaviour for UI size persistence:
- * S42-1  User can update their own ui_size
- * S42-2  Invalid value rejected by check constraint
- * S42-3  Non-owner cannot update another user's ui_size (RLS)
- * S42-4  Default value for new users is 'regular'
+ * S52-1  User can update their own ui_size across all tiers (small/medium/xl/xxl)
+ * S52-2  Invalid value rejected by check constraint
+ * S52-3  Non-owner cannot update another user's ui_size (RLS)
+ * S52-4  Default value for new users is 'medium'
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import type { SupabaseClient } from '@supabase/supabase-js'
@@ -17,8 +17,8 @@ let userClient: SupabaseClient
 let otherClient: SupabaseClient
 
 beforeAll(async () => {
-  const user = await createUser('s42-user')
-  const other = await createUser('s42-other')
+  const user = await createUser('s52-user')
+  const other = await createUser('s52-other')
 
   userId = user.id
   otherUserId = other.id
@@ -32,65 +32,34 @@ afterAll(async () => {
 })
 
 // ---------------------------------------------------------------------------
-// S42-1: User can update their own ui_size
+// S52-1: User can update their own ui_size across all tiers
 // ---------------------------------------------------------------------------
-describe('S42-1: user updates own ui_size', () => {
-  it('UPDATE succeeds and row reflects new value', async () => {
-    const { error } = await userClient
-      .from('profiles')
-      .update({ ui_size: 'large' })
-      .eq('id', userId)
+describe('S52-1: user updates own ui_size', () => {
+  it.each(['small', 'medium', 'xl', 'xxl'] as const)(
+    'UPDATE to %s succeeds and row reflects new value',
+    async (size) => {
+      const { error } = await userClient
+        .from('profiles')
+        .update({ ui_size: size })
+        .eq('id', userId)
 
-    expect(error).toBeNull()
+      expect(error).toBeNull()
 
-    const { data } = await admin
-      .from('profiles')
-      .select('ui_size')
-      .eq('id', userId)
-      .single()
+      const { data } = await admin
+        .from('profiles')
+        .select('ui_size')
+        .eq('id', userId)
+        .single()
 
-    expect(data!.ui_size).toBe('large')
-  })
-
-  it('UPDATE to xlarge succeeds', async () => {
-    const { error } = await userClient
-      .from('profiles')
-      .update({ ui_size: 'xlarge' })
-      .eq('id', userId)
-
-    expect(error).toBeNull()
-
-    const { data } = await admin
-      .from('profiles')
-      .select('ui_size')
-      .eq('id', userId)
-      .single()
-
-    expect(data!.ui_size).toBe('xlarge')
-  })
-
-  it('UPDATE back to regular succeeds', async () => {
-    const { error } = await userClient
-      .from('profiles')
-      .update({ ui_size: 'regular' })
-      .eq('id', userId)
-
-    expect(error).toBeNull()
-
-    const { data } = await admin
-      .from('profiles')
-      .select('ui_size')
-      .eq('id', userId)
-      .single()
-
-    expect(data!.ui_size).toBe('regular')
-  })
+      expect(data!.ui_size).toBe(size)
+    }
+  )
 })
 
 // ---------------------------------------------------------------------------
-// S42-2: Invalid ui_size value rejected by check constraint
+// S52-2: Invalid ui_size value rejected by check constraint
 // ---------------------------------------------------------------------------
-describe('S42-2: invalid value rejected', () => {
+describe('S52-2: invalid value rejected', () => {
   it('UPDATE with invalid size returns a check constraint error', async () => {
     const { error } = await userClient
       .from('profiles')
@@ -101,19 +70,28 @@ describe('S42-2: invalid value rejected', () => {
     // Postgres check_violation = code 23514
     expect(error!.code).toBe('23514')
   })
+
+  it('UPDATE with legacy value "regular" is rejected', async () => {
+    const { error } = await userClient
+      .from('profiles')
+      .update({ ui_size: 'regular' })
+      .eq('id', userId)
+
+    expect(error).not.toBeNull()
+    expect(error!.code).toBe('23514')
+  })
 })
 
 // ---------------------------------------------------------------------------
-// S42-3: Non-owner cannot update another user's ui_size (RLS)
+// S52-3: Non-owner cannot update another user's ui_size (RLS)
 // ---------------------------------------------------------------------------
-describe('S42-3: non-owner cannot update another profile', () => {
+describe('S52-3: non-owner cannot update another profile', () => {
   it('UPDATE on another row is blocked by RLS (0 rows affected, no error)', async () => {
-    // Seed a known baseline via admin
-    await admin.from('profiles').update({ ui_size: 'regular' }).eq('id', userId)
+    await admin.from('profiles').update({ ui_size: 'small' }).eq('id', userId)
 
     const { error } = await otherClient
       .from('profiles')
-      .update({ ui_size: 'large' })
+      .update({ ui_size: 'xl' })
       .eq('id', userId)
 
     expect(error).toBeNull()
@@ -124,21 +102,21 @@ describe('S42-3: non-owner cannot update another profile', () => {
       .eq('id', userId)
       .single()
 
-    expect(data!.ui_size).toBe('regular')
+    expect(data!.ui_size).toBe('small')
   })
 })
 
 // ---------------------------------------------------------------------------
-// S42-4: Default for new users is 'regular'
+// S52-4: Default for new users is 'medium'
 // ---------------------------------------------------------------------------
-describe('S42-4: default ui_size is regular', () => {
-  it('freshly created profile has ui_size = regular', async () => {
+describe('S52-4: default ui_size is medium', () => {
+  it('freshly created profile has ui_size = medium', async () => {
     const { data } = await admin
       .from('profiles')
       .select('ui_size')
       .eq('id', otherUserId)
       .single()
 
-    expect(data!.ui_size).toBe('regular')
+    expect(data!.ui_size).toBe('medium')
   })
 })


### PR DESCRIPTION
## Summary
- Rename `ui_size` enum values: `regular`→`small`, `large`→`medium`, `xlarge`→`xl`
- Add new `xxl` tier at 145% (23.2px) font-size
- Shift default for new profiles from `regular` (16px) to `medium` (18.4px)
- Migration 0016 drops+re-adds check constraint, maps existing rows, updates column default
- Update Settings segmented control labels (Small / Medium / XL / XXL)
- Update integration tests: parametrized all-tier update test, new default assertion, legacy-value rejection

## Closes
#52

## Human QA steps
- [ ] Sign in as existing user whose `ui_size` was `regular` — confirm Settings shows **Small** selected and text size unchanged (16px)
- [ ] Sign in as existing user whose `ui_size` was `large` — confirm shows **Medium** selected, text size unchanged (18.4px)
- [ ] Sign in as existing user whose `ui_size` was `xlarge` — confirm shows **XL** selected, text size unchanged (20.8px)
- [ ] Click **XXL** → page text grows to 23.2px; reload page → still XXL (persisted via cookie + DB)
- [ ] Click **Small** → page text returns to 16px
- [ ] Sign up a brand-new user → Settings page shows **Medium** preselected; base text size is 18.4px
- [ ] Edge case: clear the `ui-size` cookie in devtools, reload → `<html>` element has `data-size="medium"`
- [ ] Edge case: via DB, attempt `update profiles set ui_size='regular' where id=<self>` in Supabase SQL editor as the user (or check constraint test) → rejected with check_violation (23514)

🤖 Generated with [Claude Code](https://claude.com/claude-code)