### PR TITLE
fix: add user global-error to resolve RSC manifest lookup failure

### DIFF
--- a/app/src/app/global-error.tsx
+++ b/app/src/app/global-error.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+export default function GlobalError({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string }
+  unstable_retry: () => void
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <h2>Something went wrong</h2>
+        {error.digest ? <p>Ref: {error.digest}</p> : null}
+        <button type="button" onClick={() => unstable_retry()}>
+          Try again
+        </button>
+      </body>
+    </html>
+  )
+}


### PR DESCRIPTION
## Summary
- Add `app/global-error.tsx` so Turbopack doesn't try to resolve the builtin `next/dist/client/components/builtin/global-error.js` — which fails with a React Client Manifest lookup error in Next 16.2.3

## Error resolved
\`\`\`
Could not find the module "[project]/app/node_modules/next/dist/client/components/builtin/global-error.js#default" in the React Client Manifest.
\`\`\`

## Human QA steps
- [ ] Start dev server (\`pnpm dev\`) — no runtime error on any page load
- [ ] Trigger an uncaught error in the root layout (e.g. throw in \`layout.tsx\` temporarily) — custom global-error UI renders with "Something went wrong", ref digest, and "Try again" button
- [ ] Click "Try again" → attempts recovery via \`unstable_retry\`
- [ ] Normal pages (home, map, settings) load without regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)