### PR TITLE
fix: prevent horizontal overflow in Spot Modal at 375px

### DIFF
--- a/app/src/components/map/spotModal.module.css
+++ b/app/src/components/map/spotModal.module.css
@@ -103,6 +103,7 @@
   color: var(--ink);
   letter-spacing: 0.01em;
   line-height: 1.2;
+  overflow-wrap: anywhere;
 }
 
 .editIconBtn {
@@ -256,6 +257,7 @@
   color: var(--ink);
   line-height: 1.7;
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 /* ── Tags ── */
@@ -514,6 +516,7 @@
     padding-right: 0;
     border-bottom: 1px solid var(--rule);
     padding-bottom: 16px;
+    min-width: 0;
   }
 
   .galleryStrip {
@@ -523,5 +526,6 @@
   .metaCol {
     padding-left: 0;
     padding-right: 0;
+    min-width: 0;
   }
 }


### PR DESCRIPTION
## Summary
- Add `overflow-wrap: anywhere` to `.title` and `.description` in `spotModal.module.css` so long URLs and unbreakable tokens wrap instead of forcing horizontal scroll.
- Add `min-width: 0` to `.mediaCol` and `.metaCol` inside the `@media (max-width: 580px)` block — grid children default to `min-width: auto`, which lets content push columns past the viewport at 375px.

Audit confirmed the other three acceptance criteria on #17 were already satisfied by earlier PRs (side panel full-width ≤580px, Spot Modal stacks ≤580px, Add Spot + search stacked ≤640px, global `overflow-x: hidden` guard).

## Closes
#17

## Human QA steps
- [ ] Open DevTools device toolbar at 375×667 and 360×800.
- [ ] Sweep each route and confirm no horizontal body scroll on touch-swipe: `/`, `/login`, `/register`, `/forgot`, `/reset`, `/map`, `/profile`, `/settings`, `/networks`, `/networks/[id]`.
- [ ] On `/map` at 375px: open the side panel → it fills the viewport.
- [ ] Drop a Pin, open the Spot Modal → columns stack vertically.
- [ ] Edit a Spot, paste `https://example.com/a-very-long-path-that-should-wrap-instead-of-forcing-a-horizontal-scrollbar-across-the-whole-modal` into the description, save, reopen modal → description wraps, modal does not scroll horizontally.
- [ ] Upload 3+ gallery images → gallery strip scrolls horizontally **inside** the media column, but the modal itself does not scroll.
- [ ] Thumb-zone on `/map` 375px: Add Spot button and search bar both reachable with one thumb from the bottom, no collision.
- [ ] Edge case: a Spot title consisting of one long unbreakable token (e.g. `AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`) wraps in the header rather than overflowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)