### PR TITLE
feat: rebrand product name to Coppice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md — The Spot
+# CLAUDE.md — Coppice
 
 Behavioral guidelines for this codebase. Read before writing any code.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The Spot
+# Coppice
 
 Private nature spot-sharing app. Members drop Pins on a shared interactive map to create Spots — named points of interest with photos, sound clips, descriptions, and tags. Spots are only visible to Members of trusted Networks. No ads, no algorithm, no feed.
 

--- a/app/README.md
+++ b/app/README.md
@@ -1,4 +1,4 @@
-# The Spot
+# Coppice
 
 Private nature spot-sharing app. Members drop Pins on a shared interactive map to create Spots — named points of interest with photos, sound clips, descriptions, and tags. Spots are only visible to Members of trusted Networks. No ads, no algorithm, no feed.
 

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -5,7 +5,7 @@ import { isUiSizePreference, UI_SIZE_COOKIE, type UiSizePreference } from '@/lib
 import './globals.css'
 
 export const metadata: Metadata = {
-  title: 'The Spot',
+  title: 'Coppice',
   description: 'Your field journal for hidden places',
 }
 

--- a/app/src/components/landing/LandingPage.tsx
+++ b/app/src/components/landing/LandingPage.tsx
@@ -25,7 +25,7 @@ export default function LandingPage() {
   return (
     <div className={styles.page}>
       <header className={styles.nav}>
-        <span className={styles.wordmark}>The Spot</span>
+        <span className={styles.wordmark}>Coppice</span>
       </header>
 
       <section className={styles.hero}>
@@ -55,7 +55,7 @@ export default function LandingPage() {
             {screenshotExists ? (
               <Image
                 src="/landing-showcase.png"
-                alt="The Spot — map view with an open spot card"
+                alt="Coppice — map view with an open spot card"
                 fill
                 className={styles.screenshot}
                 priority={false}

--- a/app/src/components/map/MapPage.tsx
+++ b/app/src/components/map/MapPage.tsx
@@ -429,7 +429,7 @@ export default function MapPage({ spots: initialSpots, networks, userId: _userId
         }}
       >
         <div className={styles.panelHeader}>
-          <span className={styles.panelTitle}>The Spot</span>
+          <span className={styles.panelTitle}>Coppice</span>
           <button
             className={styles.menuBtn}
             onClick={() => setPanelOpen(false)}

--- a/docs/UBIQUITOUS_LANGUAGE.md
+++ b/docs/UBIQUITOUS_LANGUAGE.md
@@ -1,4 +1,4 @@
-# Ubiquitous Language — The Spot
+# Ubiquitous Language — Coppice
 
 ## Core Domain
 
@@ -88,7 +88,7 @@
 
 ## Flagged Ambiguities
 
-- **"Hub"** — used in the product description ("a hub for hikers") but should not appear in code or UI copy. The canonical term is the app name: **The Spot**. "Hub" is marketing language.
+- **"Hub"** — used in the product description ("a hub for hikers") but should not appear in code or UI copy. The canonical term is the app name: **Coppice**. "Hub" is marketing language.
 - **"User" vs "Member"** — a **User** is the authentication identity (exists in the auth system). A **Member** is a **User** in the context of a **Network**. In UI copy, prefer "Member" when referring to someone within a Network context; prefer "User" only for auth/profile contexts (login, profile settings).
 - **"Pin" vs "Spot"** — these are related but distinct. A **Spot** is the domain entity (the data, the story, the field note). A **Pin** is its map representation. You drop a **Pin** to create a **Spot**; you click a **Pin** to open a **Spot Modal**. Never use them interchangeably in code or copy.
 - **"Network"** — avoid "server" (Discord connotation), "group" (too generic), or "community" (implies public). **Network** is the canonical term: small, private, trust-based.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# The Spot — Architecture
+# Coppice — Architecture
 
 Living reference for how the app is put together. Paired with `docs/design.md` (visual system) and `docs/UBIQUITOUS_LANGUAGE.md` (domain terms). Source of truth is the `dev` branch; update this file when architecture shifts.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,4 +1,4 @@
-# The Spot — Design Document
+# Coppice — Design Document
 
 **Design direction:** Editorial Field Journal — print culture meets trail guide.
 **Stack:** Next.js 16 · React 19 · React-Leaflet · Supabase · CSS Modules
@@ -104,7 +104,7 @@ Root font-size scales with `html[data-size]` so every `rem`-based size follows a
 
 | Element | Font | Size | Weight | Style | Letter-spacing |
 |---|---|---|---|---|---|
-| Panel title ("The Spot") | `--font-serif` | `1.25rem` | `600` | normal | `0.02em` |
+| Panel title ("Coppice") | `--font-serif` | `1.25rem` | `600` | normal | `0.02em` |
 | Section label (e.g. "NETWORKS") | `--font-body` | `0.7rem` | `600` | normal | `0.12em` uppercase |
 | Network filter button | `--font-body` | `0.875rem` | `300` | normal | — |
 | Spot title (Card / Immersive) | `--font-serif` | `1.5rem` | `700` | normal | `0.01em` |

--- a/docs/prd-v1.md
+++ b/docs/prd-v1.md
@@ -1,4 +1,4 @@
-# PRD v1 — The Spot
+# PRD v1 — Coppice
 
 ## Problem Statement
 
@@ -8,7 +8,7 @@ There is no app designed to be a trusted, private, digital scrapbook for the out
 
 ## Solution
 
-The Spot is a private nature spot-sharing app built around a shared interactive map. Members drop Pins on the map to create Spots — named, documented points of interest with photos, sound clips, descriptions, and tags. Spots are only visible to Members of trusted Networks: small, private groups that users create and invite friends into. There are no ads, no recommendation algorithm, no influencers, no scrolling, no push notifications. The app is designed to send users outside, not keep them on-screen.
+Coppice is a private nature spot-sharing app built around a shared interactive map. Members drop Pins on the map to create Spots — named, documented points of interest with photos, sound clips, descriptions, and tags. Spots are only visible to Members of trusted Networks: small, private groups that users create and invite friends into. There are no ads, no recommendation algorithm, no influencers, no scrolling, no push notifications. The app is designed to send users outside, not keep them on-screen.
 
 The primary interface is the Interactive Map. Everything else — Networks, Profiles, search — is secondary. The aesthetic is Editorial Field Journal: ink on paper, serif typography, print-culture hierarchy. It should feel like opening a well-loved trail guide, not launching a social media app.
 


### PR DESCRIPTION
## Summary
- Rename product brand from **"The Spot"** → **"Coppice"** in user-visible UI strings and docs.
- Domain is `coppice.place` (to be purchased at Cloudflare Registrar; deployment wiring tracked in a separate issue).

## Scope
- User-visible strings: nav/header wordmark, `<title>`, landing hero + image alt.
- Docs: `README.md` (root + `app/`), `CLAUDE.md`, `docs/UBIQUITOUS_LANGUAGE.md`, `docs/design.md`, `docs/architecture.md`, `docs/prd-v1.md`.

## Not in scope
- **Entity terms stay unchanged**: Spot, Pin, Network, Drop, Member, Author — renaming the entity "Spot" would cascade into tables, RPCs, RLS, actions, tests. Brand-only rename.
- `package.json` name, folder structure, migration names, commit history.
- Historical prototype HTML files under `prototypes/**`.

## Closes
(no issue — prompted by domain availability constraints; deployment issue to follow)

## Human QA steps
- [ ] `pnpm dev` → visit `/`. Nav shows "Coppice"; browser tab title shows "Coppice"; landing hero wordmark shows "Coppice".
- [ ] Log in, open `/map`. Side-panel header shows "Coppice".
- [ ] `grep -r "The Spot" app/src docs README.md CLAUDE.md` returns zero hits.
- [ ] Build still green: `pnpm build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)