### PR TITLE
feat: redesign invite/register/login pages, drop localhost from post-signup message

### DIFF
--- a/app/src/app/actions/auth.ts
+++ b/app/src/app/actions/auth.ts
@@ -48,11 +48,9 @@ export async function registerAction(
     if (networkId) redirect(`/circles/${networkId}`)
   }
 
-  // No session yet (email confirmation required). If there's an invite token,
-  // tell the user to confirm their email and return to the invite link after.
   if (inviteToken && !data.session) {
     return {
-      message: `Check your email for a confirmation link. After confirming, return to ${siteUrl}/invite/${inviteToken} to join the circle.`,
+      message: 'Check your email for a confirmation link to finish joining the circle.',
     }
   }
 

--- a/app/src/app/invite/[token]/join-network-form.tsx
+++ b/app/src/app/invite/[token]/join-network-form.tsx
@@ -2,6 +2,7 @@
 
 import { useActionState } from 'react'
 import { joinByTokenAction } from '@/app/actions/invitations'
+import styles from '@/components/auth/authForm.module.css'
 
 interface Props {
   token: string
@@ -11,11 +12,11 @@ export default function JoinNetworkForm({ token }: Props) {
   const [state, action, pending] = useActionState(joinByTokenAction, undefined)
 
   return (
-    <form action={action}>
+    <form action={action} className={styles.form}>
       <input type="hidden" name="token" value={token} />
-      {state?.error && <p role="alert">{state.error}</p>}
-      <button type="submit" disabled={pending}>
-        {pending ? 'Joining…' : 'Join Circle'}
+      {state?.error && <p className={styles.error} role="alert">{state.error}</p>}
+      <button type="submit" disabled={pending} className={styles.submit}>
+        {pending ? 'Joining…' : 'Join'}
       </button>
     </form>
   )

--- a/app/src/app/invite/[token]/page.tsx
+++ b/app/src/app/invite/[token]/page.tsx
@@ -1,6 +1,8 @@
 import { redirect } from 'next/navigation'
 import { createSupabaseServerClient } from '@/lib/supabase/server'
 import JoinNetworkForm from './join-network-form'
+import AuthShell from '@/components/auth/AuthShell'
+import formStyles from '@/components/auth/authForm.module.css'
 
 interface Props {
   params: Promise<{ token: string }>
@@ -15,32 +17,46 @@ export default async function InvitePage({ params }: Props) {
 
   if (!result || result.status === 'not_found') {
     return (
-      <main>
-        <h1>Invalid invitation link.</h1>
-        <p>This invitation link is not valid.</p>
-      </main>
+      <AuthShell>
+        <div className={formStyles.card}>
+          <h1 className={formStyles.heading}>Invitation not found.</h1>
+          <p className={formStyles.bodyText}>This link doesn&apos;t match a valid invitation.</p>
+        </div>
+        <p className={formStyles.altLink}>
+          <a href="/">Go home</a>
+        </p>
+      </AuthShell>
     )
   }
 
   if (result.status === 'expired') {
     return (
-      <main>
-        <h1>Invitation expired</h1>
-        <p>This invitation has expired.</p>
-      </main>
+      <AuthShell>
+        <div className={formStyles.card}>
+          <h1 className={formStyles.heading}>Invitation expired.</h1>
+          <p className={formStyles.bodyText}>Ask the person who invited you for a fresh link.</p>
+        </div>
+        <p className={formStyles.altLink}>
+          <a href="/">Go home</a>
+        </p>
+      </AuthShell>
     )
   }
 
   if (result.status === 'revoked') {
     return (
-      <main>
-        <h1>Invitation revoked</h1>
-        <p>This invitation has been revoked.</p>
-      </main>
+      <AuthShell>
+        <div className={formStyles.card}>
+          <h1 className={formStyles.heading}>Invitation revoked.</h1>
+          <p className={formStyles.bodyText}>The inviter cancelled this invitation.</p>
+        </div>
+        <p className={formStyles.altLink}>
+          <a href="/">Go home</a>
+        </p>
+      </AuthShell>
     )
   }
 
-  // Valid token — check auth
   const {
     data: { user },
   } = await supabase.auth.getUser()
@@ -50,12 +66,12 @@ export default async function InvitePage({ params }: Props) {
   }
 
   return (
-    <main>
-      <h1>You&apos;re invited!</h1>
-      <p>
-        Join <strong>{result.network_name}</strong>
-      </p>
-      <JoinNetworkForm token={token} />
-    </main>
+    <AuthShell>
+      <div className={formStyles.card}>
+        <h1 className={formStyles.heading}>You&apos;re invited to {result.network_name}.</h1>
+        <p className={formStyles.bodyText}>Join the circle to start sharing spots.</p>
+        <JoinNetworkForm token={token} />
+      </div>
+    </AuthShell>
   )
 }

--- a/app/src/app/login/login-form.module.css
+++ b/app/src/app/login/login-form.module.css
@@ -1,0 +1,12 @@
+.forgot {
+  font-size: 0.8rem;
+  color: var(--ink-faint);
+  text-decoration: none;
+  align-self: flex-start;
+  margin-top: -0.25rem;
+}
+
+.forgot:hover {
+  color: var(--ink);
+  text-decoration: underline;
+}

--- a/app/src/app/login/login-form.tsx
+++ b/app/src/app/login/login-form.tsx
@@ -1,7 +1,10 @@
 'use client'
 
 import { useActionState } from 'react'
+import Link from 'next/link'
 import { loginAction } from '@/app/actions/auth'
+import styles from '@/components/auth/authForm.module.css'
+import localStyles from './login-form.module.css'
 
 interface Props {
   next?: string
@@ -11,31 +14,40 @@ export default function LoginForm({ next }: Props) {
   const [state, action, pending] = useActionState(loginAction, undefined)
 
   return (
-    <form action={action}>
+    <form action={action} className={styles.form}>
       {next && <input type="hidden" name="next" value={next} />}
 
-      <div>
-        <label htmlFor="email">Email</label>
-        <input id="email" name="email" type="email" required autoComplete="email" suppressHydrationWarning />
-      </div>
-
-      <div>
-        <label htmlFor="password">Password</label>
+      <label className={styles.label}>
+        Email
         <input
-          id="password"
+          name="email"
+          type="email"
+          required
+          autoComplete="email"
+          className={styles.input}
+          suppressHydrationWarning
+        />
+      </label>
+
+      <label className={styles.label}>
+        Password
+        <input
           name="password"
           type="password"
           required
           autoComplete="current-password"
+          className={styles.input}
           suppressHydrationWarning
         />
-      </div>
+      </label>
 
-      {state?.error && <p role="alert">{state.error}</p>}
+      {state?.error && <p className={styles.error} role="alert">{state.error}</p>}
 
-      <button type="submit" disabled={pending} suppressHydrationWarning>
+      <button type="submit" disabled={pending} className={styles.submit} suppressHydrationWarning>
         {pending ? 'Logging in…' : 'Log in'}
       </button>
+
+      <Link href="/forgot-password" className={localStyles.forgot}>Forgot password?</Link>
     </form>
   )
 }

--- a/app/src/app/login/page.tsx
+++ b/app/src/app/login/page.tsx
@@ -1,4 +1,6 @@
 import LoginForm from './login-form'
+import AuthShell from '@/components/auth/AuthShell'
+import formStyles from '@/components/auth/authForm.module.css'
 
 interface Props {
   searchParams: Promise<{ next?: string; error?: string }>
@@ -8,18 +10,17 @@ export default async function LoginPage({ searchParams }: Props) {
   const { next, error } = await searchParams
 
   return (
-    <main>
-      <h1>Log in</h1>
-      {error === 'invalid_link' && (
-        <p role="alert">Invalid or expired link. Please try again.</p>
-      )}
-      <LoginForm next={next} />
-      <p>
-        <a href="/forgot-password">Forgot password?</a>
-      </p>
-      <p>
+    <AuthShell>
+      <div className={formStyles.card}>
+        <h1 className={formStyles.heading}>Welcome back.</h1>
+        {error === 'invalid_link' && (
+          <p className={formStyles.error} role="alert">Invalid or expired link. Please try again.</p>
+        )}
+        <LoginForm next={next} />
+      </div>
+      <p className={formStyles.altLink}>
         Don&apos;t have an account? <a href="/register">Register</a>
       </p>
-    </main>
+    </AuthShell>
   )
 }

--- a/app/src/app/register/page.tsx
+++ b/app/src/app/register/page.tsx
@@ -1,4 +1,6 @@
 import RegisterForm from './register-form'
+import AuthShell from '@/components/auth/AuthShell'
+import formStyles from '@/components/auth/authForm.module.css'
 
 interface Props {
   searchParams: Promise<{ token?: string }>
@@ -7,12 +9,14 @@ interface Props {
 export default async function RegisterPage({ searchParams }: Props) {
   const { token } = await searchParams
   return (
-    <main>
-      <h1>Create account</h1>
-      <RegisterForm inviteToken={token} />
-      <p>
+    <AuthShell>
+      <div className={formStyles.card}>
+        <h1 className={formStyles.heading}>Create your account.</h1>
+        <RegisterForm inviteToken={token} />
+      </div>
+      <p className={formStyles.altLink}>
         Already have an account? <a href="/login">Log in</a>
       </p>
-    </main>
+    </AuthShell>
   )
 }

--- a/app/src/app/register/register-form.tsx
+++ b/app/src/app/register/register-form.tsx
@@ -2,6 +2,7 @@
 
 import { useActionState } from 'react'
 import { registerAction } from '@/app/actions/auth'
+import styles from '@/components/auth/authForm.module.css'
 
 interface Props {
   inviteToken?: string
@@ -11,34 +12,49 @@ export default function RegisterForm({ inviteToken }: Props) {
   const [state, action, pending] = useActionState(registerAction, undefined)
 
   return (
-    <form action={action}>
+    <form action={action} className={styles.form}>
       {inviteToken && <input type="hidden" name="invite_token" value={inviteToken} />}
-      <div>
-        <label htmlFor="username">Username</label>
-        <input id="username" name="username" type="text" required autoComplete="username" suppressHydrationWarning />
-      </div>
 
-      <div>
-        <label htmlFor="email">Email</label>
-        <input id="email" name="email" type="email" required autoComplete="email" suppressHydrationWarning />
-      </div>
-
-      <div>
-        <label htmlFor="password">Password</label>
+      <label className={styles.label}>
+        Username
         <input
-          id="password"
+          name="username"
+          type="text"
+          required
+          autoComplete="username"
+          className={styles.input}
+          suppressHydrationWarning
+        />
+      </label>
+
+      <label className={styles.label}>
+        Email
+        <input
+          name="email"
+          type="email"
+          required
+          autoComplete="email"
+          className={styles.input}
+          suppressHydrationWarning
+        />
+      </label>
+
+      <label className={styles.label}>
+        Password
+        <input
           name="password"
           type="password"
           required
           autoComplete="new-password"
+          className={styles.input}
           suppressHydrationWarning
         />
-      </div>
+      </label>
 
-      {state?.error && <p role="alert">{state.error}</p>}
-      {state?.message && <p>{state.message}</p>}
+      {state?.error && <p className={styles.error} role="alert">{state.error}</p>}
+      {state?.message && <p className={styles.message}>{state.message}</p>}
 
-      <button type="submit" disabled={pending} suppressHydrationWarning>
+      <button type="submit" disabled={pending} className={styles.submit} suppressHydrationWarning>
         {pending ? 'Creating account…' : 'Create account'}
       </button>
     </form>

--- a/app/src/components/auth/AuthShell.tsx
+++ b/app/src/components/auth/AuthShell.tsx
@@ -1,0 +1,11 @@
+import Link from 'next/link'
+import styles from './authShell.module.css'
+
+export default function AuthShell({ children }: { children: React.ReactNode }) {
+  return (
+    <main className={styles.page}>
+      <Link href="/" className={styles.wordmark}>Coppice</Link>
+      <div className={styles.cardWrap}>{children}</div>
+    </main>
+  )
+}

--- a/app/src/components/auth/authForm.module.css
+++ b/app/src/components/auth/authForm.module.css
@@ -1,0 +1,112 @@
+.card {
+  background: var(--panel-bg);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  padding: 2rem;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.heading {
+  font-family: var(--font-serif);
+  font-size: 1.5rem;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--ink);
+  margin: 0 0 0.5rem 0;
+}
+
+.bodyText {
+  font-size: 0.95rem;
+  font-weight: 300;
+  line-height: 1.6;
+  color: var(--sepia);
+  margin: 0 0 1.5rem 0;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--sepia);
+}
+
+.input {
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  color: var(--ink);
+  background: var(--modal-bg);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  padding: 0.6rem 0.75rem;
+  width: 100%;
+  box-sizing: border-box;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.input:focus {
+  border-color: var(--accent);
+}
+
+.error {
+  font-size: 0.85rem;
+  color: #b94a1a;
+  margin: 0;
+}
+
+.message {
+  font-size: 0.85rem;
+  color: var(--sepia);
+  margin: 0;
+}
+
+.submit {
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--paper);
+  background: var(--accent);
+  border: none;
+  border-radius: var(--radius);
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  margin-top: 0.25rem;
+  transition: opacity 0.15s;
+}
+
+.submit:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.submit:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.altLink {
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--ink-faint);
+  margin: 0;
+}
+
+.altLink a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.altLink a:hover {
+  text-decoration: underline;
+}

--- a/app/src/components/auth/authShell.module.css
+++ b/app/src/components/auth/authShell.module.css
@@ -1,0 +1,44 @@
+.page {
+  min-height: 100dvh;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-body);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2.5rem 1.25rem;
+  box-sizing: border-box;
+}
+
+.wordmark {
+  font-family: var(--font-serif);
+  font-size: 1.125rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--ink);
+  text-decoration: none;
+  margin-bottom: 3rem;
+}
+
+.wordmark:hover {
+  opacity: 0.7;
+}
+
+.cardWrap {
+  width: 100%;
+  max-width: 22rem;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 1.25rem;
+}
+
+@media (max-width: 480px) {
+  .page {
+    padding: 1.75rem 1rem;
+  }
+
+  .wordmark {
+    margin-bottom: 2rem;
+  }
+}

--- a/app/src/components/landing/LandingAuthForm.tsx
+++ b/app/src/components/landing/LandingAuthForm.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { registerAction } from '@/app/actions/auth'
 import { loginAction } from '@/app/actions/auth'
 import styles from './landingPage.module.css'
+import formStyles from '@/components/auth/authForm.module.css'
 
 type Tab = 'signup' | 'login'
 
@@ -14,7 +15,7 @@ export default function LandingAuthForm() {
   const [loginState, loginAction_, loginPending] = useActionState(loginAction, undefined)
 
   return (
-    <div className={styles.authCard}>
+    <div className={formStyles.card}>
       <div className={styles.tabs}>
         <button
           className={tab === 'signup' ? styles.tabActive : styles.tab}
@@ -33,74 +34,74 @@ export default function LandingAuthForm() {
       </div>
 
       {tab === 'signup' && (
-        <form action={signupAction} className={styles.form}>
-          <label className={styles.label}>
+        <form action={signupAction} className={formStyles.form}>
+          <label className={formStyles.label}>
             Username
             <input
               name="username"
               type="text"
               required
               autoComplete="username"
-              className={styles.input}
+              className={formStyles.input}
               suppressHydrationWarning
             />
           </label>
-          <label className={styles.label}>
+          <label className={formStyles.label}>
             Email
             <input
               name="email"
               type="email"
               required
               autoComplete="email"
-              className={styles.input}
+              className={formStyles.input}
               suppressHydrationWarning
             />
           </label>
-          <label className={styles.label}>
+          <label className={formStyles.label}>
             Password
             <input
               name="password"
               type="password"
               required
               autoComplete="new-password"
-              className={styles.input}
+              className={formStyles.input}
               suppressHydrationWarning
             />
           </label>
-          {signupState?.error && <p className={styles.error} role="alert">{signupState.error}</p>}
-          {signupState?.message && <p className={styles.message}>{signupState.message}</p>}
-          <button type="submit" disabled={signupPending} className={styles.submit} suppressHydrationWarning>
+          {signupState?.error && <p className={formStyles.error} role="alert">{signupState.error}</p>}
+          {signupState?.message && <p className={formStyles.message}>{signupState.message}</p>}
+          <button type="submit" disabled={signupPending} className={formStyles.submit} suppressHydrationWarning>
             {signupPending ? 'Creating account…' : 'Create account'}
           </button>
         </form>
       )}
 
       {tab === 'login' && (
-        <form action={loginAction_} className={styles.form}>
-          <label className={styles.label}>
+        <form action={loginAction_} className={formStyles.form}>
+          <label className={formStyles.label}>
             Email
             <input
               name="email"
               type="email"
               required
               autoComplete="email"
-              className={styles.input}
+              className={formStyles.input}
               suppressHydrationWarning
             />
           </label>
-          <label className={styles.label}>
+          <label className={formStyles.label}>
             Password
             <input
               name="password"
               type="password"
               required
               autoComplete="current-password"
-              className={styles.input}
+              className={formStyles.input}
               suppressHydrationWarning
             />
           </label>
-          {loginState?.error && <p className={styles.error} role="alert">{loginState.error}</p>}
-          <button type="submit" disabled={loginPending} className={styles.submit} suppressHydrationWarning>
+          {loginState?.error && <p className={formStyles.error} role="alert">{loginState.error}</p>}
+          <button type="submit" disabled={loginPending} className={formStyles.submit} suppressHydrationWarning>
             {loginPending ? 'Logging in…' : 'Log in'}
           </button>
           <Link href="/forgot-password" className={styles.forgot}>Forgot password?</Link>

--- a/app/src/components/landing/landingPage.module.css
+++ b/app/src/components/landing/landingPage.module.css
@@ -71,17 +71,11 @@
   justify-content: center;
 }
 
-/* ── Auth card ────────────────────────────────────── */
-
-.authCard {
-  background: var(--panel-bg);
-  border: 1px solid var(--rule);
-  border-radius: var(--radius);
-  padding: 2rem;
-  width: 100%;
+.heroForm > * {
   max-width: 22rem;
-  box-sizing: border-box;
 }
+
+/* ── Auth card ────────────────────────────────────── */
 
 .tabs {
   display: flex;
@@ -113,76 +107,6 @@
 
 .tab:hover {
   color: var(--ink);
-}
-
-.form {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  font-size: 0.8rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--sepia);
-}
-
-.input {
-  font-family: var(--font-body);
-  font-size: 0.95rem;
-  color: var(--ink);
-  background: var(--modal-bg);
-  border: 1px solid var(--rule);
-  border-radius: var(--radius);
-  padding: 0.6rem 0.75rem;
-  width: 100%;
-  box-sizing: border-box;
-  outline: none;
-  transition: border-color 0.15s;
-}
-
-.input:focus {
-  border-color: var(--accent);
-}
-
-.error {
-  font-size: 0.85rem;
-  color: #b94a1a;
-  margin: 0;
-}
-
-.message {
-  font-size: 0.85rem;
-  color: var(--sepia);
-  margin: 0;
-}
-
-.submit {
-  font-family: var(--font-body);
-  font-size: 0.95rem;
-  font-weight: 600;
-  color: var(--paper);
-  background: var(--accent);
-  border: none;
-  border-radius: var(--radius);
-  padding: 0.75rem 1rem;
-  cursor: pointer;
-  margin-top: 0.25rem;
-  transition: opacity 0.15s;
-}
-
-.submit:disabled {
-  opacity: 0.6;
-  cursor: default;
-}
-
-.submit:hover:not(:disabled) {
-  opacity: 0.85;
 }
 
 .forgot {
@@ -302,10 +226,6 @@
 
   .heroText {
     order: 1;
-  }
-
-  .authCard {
-    max-width: 100%;
   }
 
   .subline {


### PR DESCRIPTION
## Summary
- New `AuthShell` layout + shared `authForm.module.css` apply landing aesthetic (cream paper, Playfair wordmark, centered 22rem card, accent-brown CTA) to `/invite/[token]`, `/register`, `/login`. Landing keeps its split-column hero but pulls form classes from the shared module — single source of truth across all auth surfaces.
- `/invite/[token]` now renders state-specific copy in the branded card: **invitation not found / expired / revoked** each get tailored heading + body + escape link, valid state pulls `network_name` from the `lookup_invitation` RPC for `You're invited to {Circle name}.`
- Post-signup confirmation message rewritten from `Check your email for a confirmation link. After confirming, return to http://localhost:3000/invite/<token> to join the circle.` to `Check your email for a confirmation link to finish joining the circle.` — the email auto-routes back via `/auth/confirm?next=/invite/<token>`, the "return to <url>" line was leftover noise that was leaking the localhost fallback into user-facing copy.

## Test plan
- [ ] `/login` → cream bg, Coppice wordmark links to `/`, 22rem card with `Welcome back.` heading, styled fields, accent submit, altLink `Don't have an account? Register`.
- [ ] `/register` → `Create your account.` + signup form + altLink `Already have an account? Log in`.
- [ ] `/invite/<bad-token>` → `Invitation not found.` card + Go home link.
- [ ] Generate invite, open in incognito → redirects to `/register?token=...` → cream styled register page with token preserved.
- [ ] Submit register with token → message reads `Check your email for a confirmation link to finish joining the circle.` (no localhost URL).
- [ ] Click confirm email → routes to `/invite/<token>` authenticated → `You're invited to {Circle name}.` card with Join button → join → `/circles/<id>`.
- [ ] Toggle dark theme — all auth pages render via `[data-theme="dark"]` token overrides.
- [ ] Visit `/` — landing hero unchanged visually, auth tabs still work.
- [ ] 375px viewport — card fills width, copy doesn't overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)